### PR TITLE
Added vivado simulation script for dummy_core

### DIFF
--- a/hardware/LWCsrc/LWC_TB.vhd
+++ b/hardware/LWCsrc/LWC_TB.vhd
@@ -36,9 +36,9 @@ entity LWC_TB IS
         G_TEST_OSTALL       : integer := 40;
         G_LOG2_FIFODEPTH    : integer := 8;
         G_PERIOD            : time    := 10 ns;
-        G_FNAME_PDI         : string  := "../KAT/KAT_MS_32/pdi.txt";
-        G_FNAME_SDI         : string  := "../KAT/KAT_MS_32/sdi.txt";
-        G_FNAME_DO          : string  := "../KAT/KAT_MS_32/do.txt";
+        G_FNAME_PDI         : string  := "../../../../../../dummy_lwc/KAT/KAT_MS_32/pdi.txt";
+        G_FNAME_SDI         : string  := "../../../../../../dummy_lwc/KAT/KAT_MS_32/sdi.txt";
+        G_FNAME_DO          : string  := "../../../../../../dummy_lwc/KAT/KAT_MS_32/do.txt";
         G_FNAME_LOG         : string  := "log.txt";
         G_FNAME_RESULT      : string  := "result.txt"
     );

--- a/hardware/dummy_lwc/scripts/run_vivado_sim.sh
+++ b/hardware/dummy_lwc/scripts/run_vivado_sim.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+vivado -source vivado.tcl

--- a/hardware/dummy_lwc/scripts/vivado.tcl
+++ b/hardware/dummy_lwc/scripts/vivado.tcl
@@ -1,0 +1,40 @@
+set INTERFACE_REPO "../../LWCsrc"
+set CORE_SRC_DIR "../src_rtl"
+
+
+set TOP_LEVEL_NAME LWC_TB
+
+# Set implementation files
+set CORE_VHDL_SRCS [glob -type f [subst "$CORE_SRC_DIR/*.vhd"]]
+
+set INTERFACE_SRCS [subst {
+    "$INTERFACE_REPO/NIST_LWAPI_pkg.vhd"
+    "$INTERFACE_REPO/StepDownCountLd.vhd"
+    "$INTERFACE_REPO/data_piso.vhd"
+    "$INTERFACE_REPO/key_piso.vhd"
+    "$INTERFACE_REPO/data_sipo.vhd"
+    "$INTERFACE_REPO/PreProcessor.vhd"
+    "$INTERFACE_REPO/PostProcessor.vhd"
+    "$INTERFACE_REPO/fwft_fifo.vhd"
+    "$INTERFACE_REPO/LWC.vhd"
+}]
+
+set VHDL_SRCS [concat $CORE_VHDL_SRCS $INTERFACE_SRCS]
+
+
+
+# ----------------------------------------
+# Set simulation files
+set VHDL_TB_SRCS [subst {
+    "$INTERFACE_REPO/std_logic_1164_additions.vhd"
+    "$INTERFACE_REPO/$TOP_LEVEL_NAME.vhd"
+}]
+
+create_project -force "prj_$TOP_LEVEL_NAME"
+add_files -fileset sources_1 {*}$VHDL_SRCS
+add_files -fileset sim_1 {*}$VHDL_TB_SRCS
+
+update_compile_order -fileset sources_1
+update_compile_order -fileset sim_1
+
+launch_simulation


### PR DESCRIPTION
Add simulation scripts for Xilinx Vivado.
I was not able to find a way to automatically get correct source file dependency ordering using `xvhdl` and `xelab` commands directly, so here we create a project run the simulation on the project (which can also be a little more convenient if you want to continue in gui mode, or run other tasks in vivado.

I was also not able to find a way to set the generics (something similar to `xelab`'s `-generic_top` switch), so I had to manually change the KAT file paths in the testbench. Please feel free to adjust if you happen to know a better/cleaner way to do this.