### PR TITLE
Allows software directory with test vectors to be included in the con…

### DIFF
--- a/hardware/LWCsrc/LWC_TB.vhd
+++ b/hardware/LWCsrc/LWC_TB.vhd
@@ -239,29 +239,18 @@ begin
 
     uut:  entity work.LWC(structure)
     port map (
-        clk => clk,
-        
-        rst => rst,
-        
-        pdi_data => pdi_delayed,
-        
-        pdi_valid => pdi_valid,
-        
-        pdi_ready => pdi_ready,
-        
-        sdi_data => sdi_delayed,
-        
-        sdi_valid => sdi_valid,
-        
-        sdi_ready => sdi_ready,
-        
-        do_data => do,
-        
-        do_ready => do_ready,
-        
-        do_valid => do_valid,
-        
-        do_last => do_last
+        clk          => clk,
+        rst          => rst,
+        pdi_data     => pdi_delayed,
+        pdi_valid    => pdi_valid,
+        pdi_ready    => pdi_ready,
+        sdi_data     => sdi_delayed,
+        sdi_valid    => sdi_valid,
+        sdi_ready    => sdi_ready,
+        do_data      => do,
+        do_ready     => do_ready,
+        do_valid     => do_valid,
+        do_last      => do_last
     );
     --! =================== --
     --! END OF PORT MAPPING --

--- a/hardware/LWCsrc/data_piso.vhd
+++ b/hardware/LWCsrc/data_piso.vhd
@@ -45,7 +45,7 @@ entity DATA_PISO is
             data_valid_s       : out STD_LOGIC;
             data_ready_s       : in  STD_LOGIC;
 
-            data_p             : in  STD_LOGIC_VECTOR(31 downto 0);
+            data_p             : in  STD_LOGIC_VECTOR(CCW-1 downto 0);
             data_valid_p       : in  STD_LOGIC;
             data_ready_p       : out STD_LOGIC;
 

--- a/hardware/LWCsrc/key_piso.vhd
+++ b/hardware/LWCsrc/key_piso.vhd
@@ -39,7 +39,7 @@ entity KEY_PISO is
             data_valid_s       : out STD_LOGIC;
             data_ready_s       : in  STD_LOGIC;
 
-            data_p             : in  STD_LOGIC_VECTOR(31 downto 0);
+            data_p             : in  STD_LOGIC_VECTOR(CCSW-1 downto 0);
             data_valid_p       : in  STD_LOGIC;
             data_ready_p       : out STD_LOGIC
 

--- a/hardware/dummy_lwc/src_rtl/Makefile
+++ b/hardware/dummy_lwc/src_rtl/Makefile
@@ -1,10 +1,11 @@
-# LWC_ROOT variable MUST be set to the the absolute path of the LWC package's `hardware` directory.
+# LWC_ROOT variable MUST be set to the the absolute path of the LWC package's TOP directory.
 # This is the location where the `lwc.mk` file resides. 
 # $(PWD) is the currect working directory, which is assumed to be the location of user design files.
-LWC_ROOT = $(PWD)/../..
+LWC_ROOT = $(PWD)/../../..
+HW_DIR = $(LWC_ROOT)/hardware
 
 # Change if `sources_list` file is in a different location
 #SOURCE_LIST_FILE := $(CORE_ROOT)/source_list.txt
 
 # MUST include this file
-include $(LWC_ROOT)/lwc.mk
+include $(HW_DIR)/lwc.mk

--- a/hardware/dummy_lwc/src_rtl/configs/16MSconfig.ini
+++ b/hardware/dummy_lwc/src_rtl/configs/16MSconfig.ini
@@ -1,0 +1,13 @@
+[Generics]
+G_STOP_AT_FAULT  = True
+G_TEST_MODE      = 4
+G_TEST_IPSTALL   = 10
+G_TEST_ISSTALL   = 100
+G_TEST_OSTALL    = 40
+G_LOG2_FIFODEPTH = 8
+G_FNAME_PDI      = "../KAT/KAT_MS_16/pdi.txt"
+G_FNAME_SDI      = "../KAT/KAT_MS_16/sdi.txt"
+G_FNAME_DO       = "../KAT/KAT_MS_16/do.txt"
+[Variables]
+CLOCK_PERIOD     = 6.0
+VHDL_STD         = 93

--- a/hardware/dummy_lwc/src_rtl/configs/16config.ini
+++ b/hardware/dummy_lwc/src_rtl/configs/16config.ini
@@ -1,0 +1,13 @@
+[Generics]
+G_STOP_AT_FAULT  = True
+G_TEST_MODE      = 0
+G_TEST_IPSTALL   = 10
+G_TEST_ISSTALL   = 100
+G_TEST_OSTALL    = 40
+G_LOG2_FIFODEPTH = 8
+G_FNAME_PDI      = "../KAT/KAT_16/pdi.txt"
+G_FNAME_SDI      = "../KAT/KAT_16/sdi.txt"
+G_FNAME_DO       = "../KAT/KAT_16/do.txt"
+[Variables]
+CLOCK_PERIOD     = 6.0
+VHDL_STD         = 93

--- a/hardware/dummy_lwc/src_rtl/configs/32MSconfig.ini
+++ b/hardware/dummy_lwc/src_rtl/configs/32MSconfig.ini
@@ -1,0 +1,13 @@
+[Generics]
+G_STOP_AT_FAULT  = True
+G_TEST_MODE      = 4
+G_TEST_IPSTALL   = 10
+G_TEST_ISSTALL   = 100
+G_TEST_OSTALL    = 40
+G_LOG2_FIFODEPTH = 8
+G_FNAME_PDI      = "../KAT/KAT_MS_32/pdi.txt"
+G_FNAME_SDI      = "../KAT/KAT_MS_32/sdi.txt"
+G_FNAME_DO       = "../KAT/KAT_MS_32/do.txt"
+[Variables]
+CLOCK_PERIOD     = 6.0
+VHDL_STD         = 93

--- a/hardware/dummy_lwc/src_rtl/configs/32config.ini
+++ b/hardware/dummy_lwc/src_rtl/configs/32config.ini
@@ -1,0 +1,13 @@
+[Generics]
+G_STOP_AT_FAULT  = True
+G_TEST_MODE      = 0
+G_TEST_IPSTALL   = 10
+G_TEST_ISSTALL   = 100
+G_TEST_OSTALL    = 40
+G_LOG2_FIFODEPTH = 8
+G_FNAME_PDI      = "../KAT/KAT_32/pdi.txt"
+G_FNAME_SDI      = "../KAT/KAT_32/sdi.txt"
+G_FNAME_DO       = "../KAT/KAT_32/do.txt"
+[Variables]
+CLOCK_PERIOD     = 6.0
+VHDL_STD         = 93

--- a/hardware/dummy_lwc/src_rtl/configs/8MSconfig.ini
+++ b/hardware/dummy_lwc/src_rtl/configs/8MSconfig.ini
@@ -1,0 +1,13 @@
+[Generics]
+G_STOP_AT_FAULT  = True
+G_TEST_MODE      = 4
+G_TEST_IPSTALL   = 10
+G_TEST_ISSTALL   = 100
+G_TEST_OSTALL    = 40
+G_LOG2_FIFODEPTH = 8
+G_FNAME_PDI      = "../KAT/KAT_MS_8/pdi.txt"
+G_FNAME_SDI      = "../KAT/KAT_MS_8/sdi.txt"
+G_FNAME_DO       = "../KAT/KAT_MS_8/do.txt"
+[Variables]
+CLOCK_PERIOD     = 6.0
+VHDL_STD         = 93

--- a/hardware/dummy_lwc/src_rtl/configs/8config.ini
+++ b/hardware/dummy_lwc/src_rtl/configs/8config.ini
@@ -1,0 +1,13 @@
+[Generics]
+G_STOP_AT_FAULT  = True
+G_TEST_MODE      = 0
+G_TEST_IPSTALL   = 10
+G_TEST_ISSTALL   = 100
+G_TEST_OSTALL    = 40
+G_LOG2_FIFODEPTH = 8
+G_FNAME_PDI      = "../KAT/KAT_8/pdi.txt"
+G_FNAME_SDI      = "../KAT/KAT_8/sdi.txt"
+G_FNAME_DO       = "../KAT/KAT_8/do.txt"
+[Variables]
+CLOCK_PERIOD     = 6.0
+VHDL_STD         = 93

--- a/hardware/dummy_lwc/src_rtl/design_pkg.vhd
+++ b/hardware/dummy_lwc/src_rtl/design_pkg.vhd
@@ -80,14 +80,14 @@ package body Design_pkg is
          (32, 32)  -- dummy_lwc_32
       );
     -- select the correct set of parameters
-    -- alias vector_of_constants is set_of_vector_of_constants(variant);
+    alias vector_of_constants is set_of_vector_of_constants(variant);
 
 
     --! design parameters needed by the PreProcessor, PostProcessor, and LWC
     constant TAG_SIZE        : integer := 128; --! Tag size
     constant HASH_VALUE_SIZE : integer := 256; --! Hash value size
-    constant CCW             : integer := 32; --vector_of_constants(1); --! bdo/bdi width
-    constant CCSW            : integer := 32; --vector_of_constants(2); --! key width
+    constant CCW             : integer := vector_of_constants(1); --! bdo/bdi width
+    constant CCSW            : integer := vector_of_constants(2); --! key width
     constant CCWdiv8         : integer := CCW/8; -- derived from parameters above
 
 

--- a/hardware/dummy_lwc/src_rtl/test_all.sh
+++ b/hardware/dummy_lwc/src_rtl/test_all.sh
@@ -1,0 +1,23 @@
+##!/bin/bash
+export USE_DOCKER=1
+# sed to dummy_lwc_32
+sed -i 's/:= dummy_lwc_.*/:= dummy_lwc_32;/' design_pkg.vhd
+sed -i 's/constant W       : integer.*/constant W       : integer := 32;/' ../../LWCsrc/NIST_LWAPI_pkg.vhd
+export CONFIG_LOC=$PWD/configs/32config.ini
+make sim-ghdl
+export CONFIG_LOC=$PWD/configs/32MSconfig.ini
+make sim-ghdl
+# sed to dummy_16
+sed -i 's/:= dummy_lwc_.*/:= dummy_lwc_16;/' design_pkg.vhd
+sed -i 's/constant W       : integer.*/constant W       : integer := 16;/' ../../LWCsrc/NIST_LWAPI_pkg.vhd
+export CONFIG_LOC=$PWD/configs/16config.ini
+make sim-ghdl
+export CONFIG_LOC=$PWD/configs/16MSconfig.ini
+make sim-ghdl
+## sed to dummy_8
+sed -i 's/:= dummy_lwc_.*/:= dummy_lwc_8;/' design_pkg.vhd
+sed -i 's/constant W       : integer.*/constant W       : integer := 8;/' ../../LWCsrc/NIST_LWAPI_pkg.vhd
+export CONFIG_LOC=$PWD/configs/8config.ini
+make sim-ghdl
+export CONFIG_LOC=$PWD/configs/8MSconfig.ini
+make sim-ghdl

--- a/hardware/lwc.mk
+++ b/hardware/lwc.mk
@@ -1,7 +1,7 @@
-include $(LWC_ROOT)/makefiles/lwc_common.mk
-include $(LWC_ROOT)/makefiles/lwc_ghdl.mk
-include $(LWC_ROOT)/makefiles/lwc_lint.mk
-include $(LWC_ROOT)/makefiles/lwc_yosys_fpga.mk
-include $(LWC_ROOT)/makefiles/lwc_vcs.mk
-include $(LWC_ROOT)/makefiles/lwc_dc.mk
-include $(LWC_ROOT)/makefiles/lwc_vivado.mk
+include $(HW_DIR)/makefiles/lwc_common.mk
+include $(HW_DIR)/makefiles/lwc_ghdl.mk
+include $(HW_DIR)/makefiles/lwc_lint.mk
+include $(HW_DIR)/makefiles/lwc_yosys_fpga.mk
+include $(HW_DIR)/makefiles/lwc_vcs.mk
+include $(HW_DIR)/makefiles/lwc_dc.mk
+include $(HW_DIR)/makefiles/lwc_vivado.mk

--- a/hardware/makefiles/lwc_dc.mk
+++ b/hardware/makefiles/lwc_dc.mk
@@ -1,5 +1,5 @@
 
-SYNTH_FRAMEWORK_ROOT=$(realpath $(LWC_ROOT)/scripts/synth)
+SYNTH_FRAMEWORK_ROOT=$(realpath $(LWC_ROOT)/hardware/scripts/synth)
 
 DC_CMD ?= dc_shell-xg-t -64bit -topographical_mode
 DC_START_TCL=$(SYNTH_FRAMEWORK_ROOT)/tools/dc/run.tcl

--- a/hardware/makefiles/lwc_ghdl.mk
+++ b/hardware/makefiles/lwc_ghdl.mk
@@ -35,7 +35,7 @@ endif
 SIM_ONLY_VHDL_FILES := $(VHDL_ADDITIONS) $(LWC_TB) 
 SIM_VHDL_FILES = $(VHDL_FILES) $(SIM_ONLY_VHDL_FILES)
 
-GENERICS_OPTS=$(shell $(PYTHON3_BIN) $(LWC_ROOT)/scripts/config_parser.py ghdl_generics $(CORE_ROOT)/config.ini)
+GENERICS_OPTS=$(shell $(PYTHON3_BIN) $(LWC_ROOT)/hardware/scripts/config_parser.py ghdl_generics $(CONFIG_LOC))
 
 ### GHDL analyze testbench files, elaborate, and run
 .PHONY: sim-ghdl help-ghdl clean-ghdl

--- a/hardware/makefiles/lwc_icc2.mk
+++ b/hardware/makefiles/lwc_icc2.mk
@@ -1,5 +1,5 @@
 
-SYNTH_FRAMEWORK_ROOT=$(realpath $(LWC_ROOT)/scripts/synth)
+SYNTH_FRAMEWORK_ROOT=$(realpath $(LWC_ROOT)/hardware/scripts/synth)
 
 DC_CMD ?= dc_shell-xg-t -64bit -topographical_mode
 DC_START_TCL=$(SYNTH_FRAMEWORK_ROOT)/tools/icc2/run.tcl

--- a/hardware/makefiles/lwc_vcs.mk
+++ b/hardware/makefiles/lwc_vcs.mk
@@ -17,7 +17,7 @@ else
 VCS_VLOGAN_CMD := vlogan -full64 -nc -sverilog +v2k -work $(WORK_DIR) +warn=all $(VERILOG_FILES)
 endif
 
-VCS_GENERICS_OPTS=$(shell $(PYTHON3_BIN) $(LWC_ROOT)/scripts/config_parser.py vcs_generics $(CORE_ROOT)/config.ini)
+VCS_GENERICS_OPTS=$(shell $(PYTHON3_BIN) $(LWC_ROOT)/hardware/scripts/config_parser.py vcs_generics $(CONFIG_LOC))
 
 # TOOL_RUN_DIR = vcs
 

--- a/hardware/makefiles/lwc_vivado.mk
+++ b/hardware/makefiles/lwc_vivado.mk
@@ -1,5 +1,5 @@
 
-SYNTH_FRAMEWORK_ROOT=$(realpath $(LWC_ROOT)/scripts/synth)
+SYNTH_FRAMEWORK_ROOT=$(realpath $(LWC_ROOT)/hardware/scripts/synth)
 
 VIVADO_RUN_TCL=$(SYNTH_FRAMEWORK_ROOT)/tools/vivado/run.tcl
 


### PR DESCRIPTION
Kamyar,

Thanks so much for putting all the work you have into this. Suggestion: the mounted directory be LWC/ not LWC/hardware. This allows test vectors that are generated to be included with the config.ini file when they are in the software directory.