### PR TITLE
Makefile tweaks 

### DIFF
--- a/hardware/makefiles/lwc_common.mk
+++ b/hardware/makefiles/lwc_common.mk
@@ -17,7 +17,9 @@ WINPTY := $(shell command -v winpty)
 
 TOOL_RUN_DIR = $(CORE_ROOT)/run_dir
 
-DOCKER_CMD = $(WINPTY) docker run --rm -it -v /$(CORE_ROOT):/$(CORE_ROOT) -v /$(LWC_ROOT):/$(LWC_ROOT) -w $(TOOL_RUN_DIR)
+$(shell mkdir -p $(TOOL_RUN_DIR))
+
+DOCKER_CMD = $(WINPTY) docker run --rm -it -v /$(CORE_ROOT):/$(CORE_ROOT) -v /$(LWC_ROOT):/$(LWC_ROOT) -w $(TOOL_RUN_DIR) --security-opt label=disable
 
 PYTHON3_BIN = $(DOCKER_CMD) ghdl/synth:beta python3
 GHDL_BIN = $(DOCKER_CMD) ghdl/synth:beta ghdl


### PR DESCRIPTION
On my system (Fedora 32) SeLinux is enabled by default. This causes docker to fail unless run with the privileged flag or disable SeLinux separation of containers. In this case, I don't think the privileged flag is necessary, therefore I propose the flag `--security-opt label=disable` be added to the docker command so it runs on systems with SeLinux enabled like RHEL/Fedora. On systems without SeLinux, this change will have no effect. I tested on Ubuntu 20.04 and works fine.

The second change just creates the $(TOOL_RUN_DIR) directory if it does not exist. I encountered a very vague error message because docker was looking for this non-existent directory and this took some time to decipher. This change may save time for other users.