### PR TITLE
Provide support for python 3.6 ubuntu 18.04

### DIFF
--- a/software/cryptotvgen/cryptotvgen/generator.py
+++ b/software/cryptotvgen/cryptotvgen/generator.py
@@ -18,7 +18,7 @@ from enum import Enum
 
 from .options import routines
 from .log import setup_logger
-from .prepare_libs import ctgen_get_dir
+from .prepare_libs import ctgen_get_supercop_dir
 
 
 __all__ = ['gen_random', 'gen_dataset', 'gen_test_routine',
@@ -350,7 +350,7 @@ def get_cffi_path(opts, hashop):
     if opts.lib_path:
         lib_path = Path(opts.lib_path)
     else:
-        candidates_dir = Path(opts.candidates_dir) if opts.candidates_dir else ctgen_get_dir()
+        candidates_dir = Path(opts.candidates_dir) if opts.candidates_dir else ctgen_get_supercop_dir()
         lib_path = candidates_dir / 'lib'
     
     name = None


### PR DESCRIPTION
Python3.6  does not support shutil.copytree() with dirs_exist_ok option. This PR instead puts all of the supercop files into .cryptotvgen/supercop/. This allows the entire directory to be removed with each run of prepare_libs.