### PR TITLE
Revert ASYNC_RSTN back to NIST_LWAPI_pkg

### DIFF
--- a/hardware/LWCsrc/LWC.vhd
+++ b/hardware/LWCsrc/LWC.vhd
@@ -247,7 +247,6 @@ begin
             );
     Inst_Header_Fifo: entity work.fwft_fifo(structure)
         generic map (
-                G_ASYNC_RSTN    => ASYNC_RSTN,
                 G_W             => W,
                 G_LOG2DEPTH     => 2
             )

--- a/hardware/LWCsrc/LWC_TB.vhd
+++ b/hardware/LWCsrc/LWC_TB.vhd
@@ -24,7 +24,6 @@ use std.textio.all;
 
 use work.lwc_std_logic_1164_additions.all;
 use work.NIST_LWAPI_pkg.all;
-use work.design_pkg.ASYNC_RSTN;
 
 
 entity LWC_TB IS
@@ -194,7 +193,6 @@ begin
     --! ============ --
     genPDIfifo: entity work.fwft_fifo(structure)
 	    generic map (
-	        G_ASYNC_RSTN => ASYNC_RSTN,
 	        G_W          => G_PWIDTH,
 	        G_LOG2DEPTH  => G_LOG2_FIFODEPTH)
 	    port map (
@@ -215,7 +213,6 @@ begin
 
     genSDIfifo: entity work.fwft_fifo(structure)
 	    generic map (
-	        G_ASYNC_RSTN => ASYNC_RSTN,
 	        G_W          => G_SWIDTH,
 	        G_LOG2DEPTH  => G_LOG2_FIFODEPTH)
 	    port map (
@@ -236,7 +233,6 @@ begin
 
     genDOfifo: entity work.fwft_fifo(structure)
 	    generic map (
-	        G_ASYNC_RSTN => ASYNC_RSTN,
 	        G_W          => G_PWIDTH,
 	        G_LOG2DEPTH  => G_LOG2_FIFODEPTH)
 	    port map (

--- a/hardware/LWCsrc/NIST_LWAPI_pkg.vhd
+++ b/hardware/LWCsrc/NIST_LWAPI_pkg.vhd
@@ -30,6 +30,12 @@ package NIST_LWAPI_pkg is
     --! External bus: supported values are 8, 16 and 32 bits
     constant W       : integer := 32;
     constant SW      : integer := W;
+    
+        
+    --! Asynchronous and active-low reset.
+    --! Can be set to `True` when targeting ASICs given that your CryptoCore supports it.
+    constant ASYNC_RSTN      : boolean := false;
+    
 
     --! Default values for do_data bus
     --! to avoid leaking intermeadiate values if do_valid = '0'.

--- a/hardware/LWCsrc/fwft_fifo.vhd
+++ b/hardware/LWCsrc/fwft_fifo.vhd
@@ -20,7 +20,6 @@ use work.NIST_LWAPI_pkg.all;
 
 entity fwft_fifo is
 	generic(
-		G_ASYNC_RSTN: boolean;
         G_W         : integer; --! Width of I/O (bits)
         G_LOG2DEPTH : integer  --! LOG(2) of depth
     );
@@ -97,7 +96,7 @@ begin
     	end if;
     end process p_mem;
     	
-	GEN_p_ptr_SYNC_RST: if (not G_ASYNC_RSTN) generate
+	GEN_p_ptr_SYNC_RST: if (not ASYNC_RSTN) generate
     p_ptr : process(clk)
     begin
         if rising_edge(clk) then
@@ -114,7 +113,7 @@ begin
     end process p_ptr;
 	end generate GEN_p_ptr_SYNC_RST;
 
-	GEN_p_ptr_ASYNC_RSTN: if (G_ASYNC_RSTN) generate
+	GEN_p_ptr_ASYNC_RSTN: if (ASYNC_RSTN) generate
     p_ptr : process(clk, rst)
     begin
 	    if (rst = '0') then

--- a/hardware/dummy_lwc/design.json
+++ b/hardware/dummy_lwc/design.json
@@ -1,0 +1,93 @@
+{
+    "design": {
+        "name": "dummy_lwc",
+        "description": "Implementation of the dummy_lwc cipher and hash",
+        "author": [
+            "[Patrick Karl](patrick.karl@tum.de)"
+        ],
+        "url": "https://github.com/GMUCERG/LWC",
+        "sources": [
+            {
+                "file": "src_rtl/design_pkg.vhd"
+            },
+            {
+                "file": "src_rtl/LWC/NIST_LWAPI_pkg.vhd"
+            },
+            {
+                "file": "src_rtl/SPDRam.vhd"
+            },
+            {
+                "file": "src_rtl/CryptoCore.vhd"
+            },
+            {
+                "file": "src_rtl/LWC/StepDownCountLd.vhd"
+            },
+            {
+                "file": "src_rtl/LWC/data_sipo.vhd"
+            },
+            {
+                "file": "src_rtl/LWC/key_piso.vhd"
+            },
+            {
+                "file": "src_rtl/LWC/data_piso.vhd"
+            },
+            {
+                "file": "src_rtl/LWC/fwft_fifo.vhd"
+            },
+            {
+                "file": "src_rtl/LWC/PreProcessor.vhd"
+            },
+            {
+                "file": "src_rtl/LWC/PostProcessor.vhd"
+            },
+            {
+                "file": "src_rtl/LWC/LWC.vhd"
+            },
+            {
+                "file": "src_tb/lwc_std_logic_1164_additions.vhd",
+                "sim_only": true
+            },
+            {
+                "file": "src_tb/LWC_TB.vhd",
+                "sim_only": true
+            }
+        ],
+        "vhdl_std": "02",
+        "vhdl_synopsys": true,
+        "top": "LWC",
+        "clock_port": "clk",
+        "tb_top": "LWC_TB",
+        "tb_generics": {
+            "G_FNAME_PDI": {
+                "file": "KAT/KAT_32/pdi.txt"
+            },
+            "G_FNAME_SDI": {
+                "file": "KAT/KAT_32/sdi.txt"
+            },
+            "G_FNAME_DO": {
+                "file": "KAT/KAT_32/do.txt"
+            }
+        },
+        "generics": {}
+    },
+    "flows": {
+        "diamond": {
+            "fpga_part": "LFE5U-25F-6BG381C",
+            "clock_period": 12.0,
+            "synthesis_engine": "synplify",
+            "strategy": "Timing"
+        },
+        "vivado": {
+            "fpga_part": "xc7a12tcsg325-3",
+            "clock_period": 5.0,
+            "strategy": "Timing",
+            "optimize_power": "False",
+            "sim_run": "all"
+        },
+        "quartus": {
+            "fpga_part": "10CL016YU256C6G",
+            "strategy": "Timing",
+            "clock_period": 6.1
+        }
+    }
+}

--- a/hardware/dummy_lwc/test_all.py
+++ b/hardware/dummy_lwc/test_all.py
@@ -177,24 +177,25 @@ def test_all():
         for ms in [False, True]:
             replace_files_map = {}
             for w, ccw in param_variants:
-                replaced_lwapi_pkg = (
-                    generated_sources / f'NIST_LWAPI_pkg_W{w}.vhd').resolve()
-                lwapi_pkg_changes = [
-                    (r'(constant\s+W\s*:\s*integer\s*:=\s*)(\d+)(\s*;)', f'\\g<1>{w}\\g<3>')
-                ]
-                gen_from_template(orig_lwapi_pkg, replaced_lwapi_pkg, lwapi_pkg_changes)
-                replace_files_map[orig_lwapi_pkg] = replaced_lwapi_pkg
 
                 for async_rstn in [False, True]:
+                    replaced_lwapi_pkg = (
+                        generated_sources / f'NIST_LWAPI_pkg_W{w}{"_ASYNC_RSTN" if async_rstn else ""}.vhd').resolve()
+                    lwapi_pkg_changes = [
+                        (r'(constant\s+W\s*:\s*integer\s*:=\s*)(\d+)(\s*;)', f'\\g<1>{w}\\g<3>'),
+                        (r'(constant\s+ASYNC_RSTN\s+:\s+boolean\s+:=\s+).*;', f'\\g<1>{async_rstn};')
+                    ]
+                    gen_from_template(orig_lwapi_pkg, replaced_lwapi_pkg, lwapi_pkg_changes)
+                    replace_files_map[orig_lwapi_pkg] = replaced_lwapi_pkg
+
                     print(f'\n\n{"="*12}- Testing vhdl_std={vhdl_std} ms={ms} w={w} ccw={ccw} async_rstn={async_rstn} -{"="*12}\n')
                     gen_tv_dir = gen_tv_subfolder / f'TV{"_MS" if ms else ""}_{w}'
                     gen_tv(w, 2 if ms else None, gen_tv_dir)
 
                     replaced_design_pkg = (
-                        generated_sources / f'design_pkg_{ccw}{"_arstn" if async_rstn else ""}.vhd').resolve()
+                        generated_sources / f'design_pkg_{ccw}.vhd').resolve()
                     design_pkg_changes = [
-                        (r'(constant\s+variant\s+:\s+set_selector\s+:=\s+)dummy_lwc_.*;', f'\\g<1>dummy_lwc_{ccw};'),
-                        (r'(constant\s+ASYNC_RSTN\s+:\s+boolean\s+:=\s+).*;', f'\\g<1>{async_rstn};')
+                        (r'(constant\s+variant\s+:\s+set_selector\s+:=\s+)dummy_lwc_.*;', f'\\g<1>dummy_lwc_{ccw};')
                     ]
                     gen_from_template(orig_design_pkg, replaced_design_pkg, design_pkg_changes)
                     replace_files_map[orig_design_pkg] = replaced_design_pkg

--- a/hardware/dummy_lwc/test_all.py
+++ b/hardware/dummy_lwc/test_all.py
@@ -182,8 +182,8 @@ def test_all():
                     replaced_lwapi_pkg = (
                         generated_sources / f'NIST_LWAPI_pkg_W{w}{"_ASYNC_RSTN" if async_rstn else ""}.vhd').resolve()
                     lwapi_pkg_changes = [
-                        (r'(constant\s+W\s*:\s*integer\s*:=\s*)(\d+)(\s*;)', f'\\g<1>{w}\\g<3>'),
-                        (r'(constant\s+ASYNC_RSTN\s+:\s+boolean\s+:=\s+).*;', f'\\g<1>{async_rstn};')
+                        (r'(constant\s+W\s*:\s*integer\s*:=\s*)\d+(\s*;)', f'\\g<1>{w}\\g<2>'),
+                        (r'(constant\s+ASYNC_RSTN\s*:\s+boolean\s*:=\s*)\w+(\s*;)', f'\\g<1>{async_rstn}\\g<2>')
                     ]
                     gen_from_template(orig_lwapi_pkg, replaced_lwapi_pkg, lwapi_pkg_changes)
                     replace_files_map[orig_lwapi_pkg] = replaced_lwapi_pkg
@@ -195,7 +195,7 @@ def test_all():
                     replaced_design_pkg = (
                         generated_sources / f'design_pkg_{ccw}.vhd').resolve()
                     design_pkg_changes = [
-                        (r'(constant\s+variant\s+:\s+set_selector\s+:=\s+)dummy_lwc_.*;', f'\\g<1>dummy_lwc_{ccw};')
+                        (r'(constant\s+variant\s*:\s*set_selector\s*:=\s*dummy_lwc_)\d+(\s*;)', f'\\g<1>{ccw}\\g<2>')
                     ]
                     gen_from_template(orig_design_pkg, replaced_design_pkg, design_pkg_changes)
                     replace_files_map[orig_design_pkg] = replaced_design_pkg


### PR DESCRIPTION
Move `ASYNC_RSTN` constant back to `NIST_LWAPI_pkg.vhd` (at least for now) to make it possible to use `LWC_TB.vhd` with implementations using previous releases of LWC package.