### PR TITLE
WIP: fixes and improvements for TB and cyptotvgen

### DIFF
--- a/hardware/LWC_rtl/LWC_2pass.vhd
+++ b/hardware/LWC_rtl/LWC_2pass.vhd
@@ -1,8 +1,7 @@
 --------------------------------------------------------------------------------
---! @file       LWC.vhd (CAESAR API for Lightweight)
---! @brief      LWC top level file
---! @author     Panasayya Yalla & Ekawat (ice) Homsirikamol
---! @copyright  Copyright (c) 2016 Cryptographic Engineering Research Group
+--! @file       LWC_2pass.vhd
+--! @brief      LWC_2pass top level file
+--! @copyright  Copyright (c) 2020 Cryptographic Engineering Research Group
 --!             ECE Department, George Mason University Fairfax, VA, U.S.A.
 --!             All rights Reserved.
 --! @license    This project is released under the GNU Public License.
@@ -28,7 +27,7 @@ use ieee.std_logic_1164.all;
 use work.design_pkg.all;
 use work.NIST_LWAPI_pkg.all;
 
-entity LWC is
+entity LWC_2pass is
     port (
         --! Global ports
         clk             : in  std_logic;
@@ -39,18 +38,26 @@ entity LWC is
         pdi_ready       : out std_logic;
         --! Secret data ports
         -- NOTE for future dev: this G_W is really SW!
-        sdi_data        : in  std_logic_vector(SW-1 downto 0);
+        sdi_data        : in  std_logic_vector(W-1 downto 0);
         sdi_valid       : in  std_logic;
         sdi_ready       : out std_logic;
         --! Data out ports
         do_data         : out std_logic_vector(W-1 downto 0);
         do_ready        : in  std_logic;
         do_valid        : out std_logic;
-        do_last         : out std_logic
-    );
-end LWC;
+        do_last         : out std_logic;
 
-architecture structure of LWC is
+        fdi_data         : in std_logic_vector(CCW-1 downto 0);
+        fdi_valid        : in std_logic;
+        fdi_ready        : out  std_logic;
+        fdo_data         : out std_logic_vector(CCW-1 downto 0);
+        fdo_valid        : out std_logic;
+        fdo_ready        : in  std_logic;
+        fdi_last : in std_logic
+    );
+end LWC_2pass;
+
+architecture structure of LWC_2pass is
 	
     --==========================================================================
     --!Cipher
@@ -81,7 +88,7 @@ architecture structure of LWC is
     signal end_of_block_cipher_out  : std_logic;
     -- signal bdo_size_cipher_out      : std_logic_vector(3       -1 downto 0);
     signal bdo_valid_bytes_cipher_out:std_logic_vector(CCWdiv8 -1 downto 0);
-    signal bdo_type_cipher_out      :std_logic_vector(4        -1 downto 0);
+--    signal bdo_type_cipher_out      :std_logic_vector(4        -1 downto 0);
     -- signal decrypt_cipher_out       : std_logic;
     signal msg_auth_valid           : std_logic;
     signal msg_auth_ready           : std_logic;
@@ -100,63 +107,33 @@ architecture structure of LWC is
     signal cmd_FIFO_out             : std_logic_vector(W-1 downto 0);
     signal cmd_valid_FIFO_out       : std_logic;
     signal cmd_ready_FIFO_out       : std_logic;
-    
     --==========================================================================
     
-    component CryptoCore
-        port(
-            clk             : in  STD_LOGIC;
-            rst             : in  STD_LOGIC;
-            key             : in  STD_LOGIC_VECTOR(CCSW - 1 downto 0);
-            key_valid       : in  STD_LOGIC;
-            key_ready       : out STD_LOGIC;
-            bdi             : in  STD_LOGIC_VECTOR(CCW - 1 downto 0);
-            bdi_valid       : in  STD_LOGIC;
-            bdi_ready       : out STD_LOGIC;
-            bdi_pad_loc     : in  STD_LOGIC_VECTOR(CCWdiv8 - 1 downto 0);
-            bdi_valid_bytes : in  STD_LOGIC_VECTOR(CCWdiv8 - 1 downto 0);
-            bdi_size        : in  STD_LOGIC_VECTOR(3 - 1 downto 0);
-            bdi_eot         : in  STD_LOGIC;
-            bdi_eoi         : in  STD_LOGIC;
-            bdi_type        : in  STD_LOGIC_VECTOR(4 - 1 downto 0);
-            decrypt_in      : in  STD_LOGIC;
-            key_update      : in  STD_LOGIC;
-            hash_in         : in  std_logic;
-            bdo             : out STD_LOGIC_VECTOR(CCW - 1 downto 0);
-            bdo_valid       : out STD_LOGIC;
-            bdo_ready       : in  STD_LOGIC;
-            bdo_type        : out STD_LOGIC_VECTOR(4 - 1 downto 0);
-            bdo_valid_bytes : out STD_LOGIC_VECTOR(CCWdiv8 - 1 downto 0);
-            end_of_block    : out STD_LOGIC;
-            msg_auth_valid  : out STD_LOGIC;
-            msg_auth_ready  : in  STD_LOGIC;
-            msg_auth        : out STD_LOGIC
-        );
-    end component CryptoCore;
+
 begin
 
 	-- Width parameters sanity checks
-	-- See 'Implementer’s Guide to Hardware Implementations Compliant with the Hardware API for LWC', sec. 4.3:
+	-- See 'Implementer’s Guide to Hardware Implementations Compliant with the Hardware API for LWC_2pass', sec. 4.3:
 	-- "The following combinations (w, ccw) are supported in the current version
     --   of the Development Package: (32, 32), (32, 16), (32, 8), (16, 16), and (8, 8).
     --   The following combinations (sw, ccsw) are supported: (32, 32), (32, 16),
     --   (32, 8), (16, 16), and (8, 8). However, w and sw must be always the same."
 
-    assert false report "[LWC] GW=" & integer'image(W) &
+    assert false report "[LWC_2pass] GW=" & integer'image(W) &
         ", SW=" & integer'image(SW) &
         ", CCW=" & integer'image(CCW) &
         ", CCSW=" & integer'image(CCSW) severity note;
     
     assert ((W = 32 and (CCW = 32 or CCW = 16 or CCW = 8)) or 
     	(W = 16 and CCW = 16) or (W = 8 and CCW = 8)) 
-    	report "[LWC] Invalid combination of (G_W, CCW)" severity failure;
+    	report "[LWC_2pass] Invalid combination of (G_W, CCW)" severity failure;
     	
     assert ((SW = 32 and (CCSW = 32 or CCSW = 16 or CCSW = 8)) or 
     	(SW = 16 and CCSW = 16) or (SW = 8 and CCSW = 8)) 
-    	report "[LWC] Invalid combination of (SW, CCSW)" severity failure;
+    	report "[LWC_2pass] Invalid combination of (SW, CCSW)" severity failure;
 	
 	-- ASYNC_RSTN notification
-    assert (ASYNC_RSTN = false) report "[LWC] ASYNC_RSTN=True: reset is configured as asynchronous and active-low" severity note;
+    assert (ASYNC_RSTN = false) report "[LWC_2pass] ASYNC_RSTN=True: reset is configured as asynchronous and active-low" severity note;
 
     Inst_PreProcessor: entity work.PreProcessor(PreProcessor)
     	generic map(
@@ -192,59 +169,66 @@ begin
                 cmd_valid       => cmd_valid_FIFO_in                       ,
                 cmd_ready       => cmd_ready_FIFO_in
             );
-    Inst_Cipher: CryptoCore
+    Inst_Cipher: entity work.CryptoCore
         port map(
-                clk             => clk,
-                rst             => rst,
-                key             => key_cipher_in,
-                key_valid       => key_valid_cipher_in,
-                key_ready       => key_ready_cipher_in,
-                bdi             => bdi_cipher_in,
-                bdi_valid       => bdi_valid_cipher_in,
-                bdi_ready       => bdi_ready_cipher_in,
-                bdi_pad_loc     => bdi_pad_loc_cipher_in,
-                bdi_valid_bytes => bdi_valid_bytes_cipher_in,
-                bdi_size        => bdi_size_cipher_in,
-                bdi_eot         => bdi_eot_cipher_in,
-                bdi_eoi         => bdi_eoi_cipher_in,
-                bdi_type        => bdi_type_cipher_in,
-                decrypt_in      => decrypt_cipher_in,
-                key_update      => key_update_cipher_in,
-                hash_in         => hash_cipher_in,
-                bdo             => bdo_cipher_out,
-                bdo_valid       => bdo_valid_cipher_out,
-                bdo_ready       => bdo_ready_cipher_out,
-                bdo_type        => bdo_type_cipher_out,
-                bdo_valid_bytes => bdo_valid_bytes_cipher_out,
-                end_of_block    => end_of_block_cipher_out,
-                msg_auth_valid  => msg_auth_valid,
-                msg_auth_ready  => msg_auth_ready,
-                msg_auth        => msg_auth
+                clk             => clk                                     ,
+                rst             => rst                                     ,
+                key             => key_cipher_in                           ,
+                key_valid       => key_valid_cipher_in                     ,
+                key_ready       => key_ready_cipher_in                     ,
+                bdi             => bdi_cipher_in                           ,
+                bdi_valid       => bdi_valid_cipher_in                     ,
+                bdi_ready       => bdi_ready_cipher_in                     ,
+                bdi_pad_loc     => bdi_pad_loc_cipher_in                   ,
+                bdi_valid_bytes => bdi_valid_bytes_cipher_in               ,
+                bdi_size        => bdi_size_cipher_in                      ,
+                bdi_eot         => bdi_eot_cipher_in                       ,
+                bdi_eoi         => bdi_eoi_cipher_in                       ,
+                bdi_type        => bdi_type_cipher_in                      ,
+                decrypt_in      => decrypt_cipher_in                       ,
+                hash_in         => hash_cipher_in                          ,
+                key_update      => key_update_cipher_in                    ,
+                bdo             => bdo_cipher_out                          ,
+                bdo_valid       => bdo_valid_cipher_out                    ,
+                bdo_ready       => bdo_ready_cipher_out                    ,
+--                bdo_type        => bdo_type_cipher_out                     ,
+                bdo_valid_bytes => bdo_valid_bytes_cipher_out              ,
+                end_of_block    => end_of_block_cipher_out                 ,
+                msg_auth_valid  => msg_auth_valid                          ,
+                msg_auth_ready  => msg_auth_ready                          ,
+                msg_auth        => msg_auth,
+                fdi_data        => fdi_data                                ,
+                fdi_valid       => fdi_valid                               ,
+                fdi_ready       => fdi_ready                               ,
+                fdo_valid       => fdo_valid                               ,
+                fdo_ready       => fdo_ready,
+                fdo_data        => fdo_data,
+                fdi_last => fdi_last
             );
-    Inst_PostProcessor: entity work.PostProcessor
+    Inst_PostProcessor: entity work.PostProcessor(PostProcessor)
     	generic map(
-        		G_W             => W,
-        		G_ASYNC_RSTN    => ASYNC_RSTN
+        		G_W            => W,
+        		G_ASYNC_RSTN   => ASYNC_RSTN
         	)
         port map(
-                clk             => clk,
-                rst             => rst,
-                bdo             => bdo_cipher_out,
-                bdo_valid       => bdo_valid_cipher_out,
-                bdo_ready       => bdo_ready_cipher_out,
-                end_of_block    => end_of_block_cipher_out,
-                bdo_type        => bdo_type_cipher_out,
-                bdo_valid_bytes => bdo_valid_bytes_cipher_out,
-                msg_auth        => msg_auth,
-                msg_auth_ready  => msg_auth_ready,
-                msg_auth_valid  => msg_auth_valid,
-                cmd             => cmd_FIFO_out,
-                cmd_valid       => cmd_valid_FIFO_out,
-                cmd_ready       => cmd_ready_FIFO_out,
-                do_data         => do_data,
-                do_valid        => do_valid,
-                do_last         => do_last,
-                do_ready        => do_ready
+                clk             => clk                                     ,
+                rst             => rst                                     ,
+                bdo             => bdo_cipher_out                          ,
+                bdo_valid       => bdo_valid_cipher_out                    ,
+                bdo_ready       => bdo_ready_cipher_out                    ,
+                end_of_block    => end_of_block_cipher_out                 ,
+--                bdo_type        => bdo_type_cipher_out                     ,
+                bdo_valid_bytes => bdo_valid_bytes_cipher_out              ,
+                cmd             => cmd_FIFO_out                            ,
+                cmd_valid       => cmd_valid_FIFO_out                      ,
+                cmd_ready       => cmd_ready_FIFO_out                      ,
+                do_data         => do_data                                 ,
+                do_valid        => do_valid                                ,
+                do_last         => do_last                                 ,
+                do_ready        => do_ready                                ,
+                msg_auth_valid  => msg_auth_valid                          ,
+                msg_auth_ready  => msg_auth_ready                          ,
+                msg_auth        => msg_auth
             );
     Inst_Header_Fifo: entity work.fwft_fifo(structure)
         generic map (
@@ -261,5 +245,6 @@ begin
                 dout_valid      => cmd_valid_FIFO_out,
                 dout_ready      => cmd_ready_FIFO_out
             );
-    
+
+
 end structure;

--- a/hardware/LWC_rtl/LWC_2pass_wrapper.vhd
+++ b/hardware/LWC_rtl/LWC_2pass_wrapper.vhd
@@ -1,0 +1,179 @@
+library ieee;
+use ieee.std_logic_1164.all;
+
+use work.NIST_LWAPI_pkg.all;
+
+entity LWC_2pass_wrapper is
+    port (
+        clk             : in  std_logic;
+        rst             : in  std_logic;
+        pdi_data        : in  std_logic_vector(W-1 downto 0);
+        pdi_valid       : in  std_logic;
+        pdi_ready       : out std_logic;
+        sdi_data        : in  std_logic_vector(SW-1 downto 0);
+        sdi_valid       : in  std_logic;
+        sdi_ready       : out std_logic;
+        do_data         : out std_logic_vector(W-1 downto 0);
+        do_ready        : in  std_logic;
+        do_valid        : out std_logic;
+        do_last         : out std_logic;
+        fdi_data        : in  std_logic_vector(W-1 downto 0);
+        fdi_valid       : in  std_logic;
+        fdi_ready       : out std_logic;
+        fdo_data        : out std_logic_vector(W-1 downto 0);
+        fdo_valid       : out std_logic;
+        fdo_ready       : in  std_logic
+    );
+end LWC_2pass_wrapper;
+
+architecture RTL of LWC_2pass_wrapper is
+    signal lwc_pdi_data  : std_logic_vector(W-1 downto 0);
+    signal lwc_pdi_valid : std_logic;
+    signal lwc_pdi_ready : std_logic;
+    signal lwc_sdi_data  : std_logic_vector(SW-1 downto 0);
+    signal lwc_sdi_valid : std_logic;
+    signal lwc_sdi_ready : std_logic;
+    signal lwc_do_data   : std_logic_vector(W-1 downto 0);
+    signal lwc_do_ready  : std_logic;
+    signal lwc_do_valid  : std_logic;
+    signal lwc_do_last   : std_logic;
+    signal lwc_fdi_data  : std_logic_vector(W-1 downto 0);
+    signal lwc_fdi_valid : std_logic;
+    signal lwc_fdi_ready : std_logic;
+    signal lwc_fdo_data  : std_logic_vector(W-1 downto 0);
+    signal lwc_fdo_valid : std_logic;
+    signal lwc_fdo_ready : std_logic;
+    
+    signal do_datalast_i : std_logic_vector(W downto 0);
+    signal do_datalast_o : std_logic_vector(W downto 0);
+
+    component LWC_2pass
+    port(
+        clk       : in  std_logic;
+        rst       : in  std_logic;
+        pdi_data  : in  std_logic_vector(W - 1 downto 0);
+        pdi_valid : in  std_logic;
+        pdi_ready : out std_logic;
+        sdi_data  : in  std_logic_vector(SW - 1 downto 0);
+        sdi_valid : in  std_logic;
+        sdi_ready : out std_logic;
+        do_data   : out std_logic_vector(W - 1 downto 0);
+        do_ready  : in  std_logic;
+        do_valid  : out std_logic;
+        do_last   : out std_logic;
+        fdi_data  : in  std_logic_vector(W - 1 downto 0);
+        fdi_valid : in  std_logic;
+        fdi_ready : out std_logic;
+        fdo_data  : out std_logic_vector(W - 1 downto 0);
+        fdo_valid : out std_logic;
+        fdo_ready : in  std_logic
+    );
+    end component LWC_2pass;
+
+begin
+
+    assert False report "Using LWC_2pass_wrapper" severity warning;
+    
+    LWC_inst : LWC_2pass
+        port map(
+            clk       => clk,
+            rst       => rst,
+            pdi_data  => lwc_pdi_data,
+            pdi_valid => lwc_pdi_valid,
+            pdi_ready => lwc_pdi_ready,
+            sdi_data  => lwc_sdi_data,
+            sdi_valid => lwc_sdi_valid,
+            sdi_ready => lwc_sdi_ready,
+            do_data   => lwc_do_data,
+            do_ready  => lwc_do_ready,
+            do_valid  => lwc_do_valid,
+            do_last   => lwc_do_last,
+            fdi_data  => lwc_fdi_data,
+            fdi_valid => lwc_fdi_valid,
+            fdi_ready => lwc_fdi_ready,
+            fdo_data  => lwc_fdo_data,
+            fdo_valid => lwc_fdo_valid,
+            fdo_ready => lwc_fdo_ready
+        );
+    
+    elastic_reg_fifo_pdi : entity work.elastic_reg_fifo
+        generic map(
+            W => W
+        )
+        port map(
+            clk       => clk,
+            reset     => rst,
+            in_data   => pdi_data,
+            in_valid  => pdi_valid,
+            in_ready  => pdi_ready,
+            out_data  => lwc_pdi_data,
+            out_valid => lwc_pdi_valid,
+            out_ready => lwc_pdi_ready
+        );
+
+    
+    elastic_reg_fifo_sdi : entity work.elastic_reg_fifo
+        generic map(
+            W => SW
+        )
+        port map(
+            clk       => clk,
+            reset     => rst,
+            in_data   => sdi_data,
+            in_valid  => sdi_valid,
+            in_ready  => sdi_ready,
+            out_data  => lwc_sdi_data,
+            out_valid => lwc_sdi_valid,
+            out_ready => lwc_sdi_ready
+        );
+        
+    elastic_reg_fifo_do : entity work.elastic_reg_fifo
+        generic map(
+            W => W+1
+        )
+        port map(
+            clk       => clk,
+            reset     => rst,
+            in_data   => do_datalast_i,
+            in_valid  => lwc_do_valid,
+            in_ready  => lwc_do_ready,
+            out_data  => do_datalast_o,
+            out_valid => do_valid,
+            out_ready => do_ready
+        );   
+
+    elastic_reg_fifo_fdi : entity work.elastic_reg_fifo
+        generic map(
+            W => W
+        )
+        port map(
+            clk       => clk,
+            reset     => rst,
+            in_data   => fdi_data,
+            in_valid  => fdi_valid,
+            in_ready  => fdi_ready,
+            out_data  => lwc_fdi_data,
+            out_valid => lwc_fdi_valid,
+            out_ready => lwc_fdi_ready
+        );       
+
+    elastic_reg_fifo_fdo : entity work.elastic_reg_fifo
+        generic map(
+            W => W
+        )
+        port map(
+            clk       => clk,
+            reset     => rst,
+            in_data   => lwc_fdo_data,
+            in_valid  => lwc_fdo_valid,
+            in_ready  => lwc_fdo_ready,
+            out_data  => fdo_data,
+            out_valid => fdo_valid,
+            out_ready => fdo_ready
+        );
+        
+    do_datalast_i <= lwc_do_last & lwc_do_data;
+    do_last <= do_datalast_o(W);
+    do_data <= do_datalast_o(W-1 downto 0);  
+    
+end architecture;

--- a/hardware/LWC_rtl/LWC_wrapper.vhd
+++ b/hardware/LWC_rtl/LWC_wrapper.vhd
@@ -1,0 +1,126 @@
+library ieee;
+use ieee.std_logic_1164.all;
+
+use work.NIST_LWAPI_pkg.all;
+
+entity LWC_wrapper is
+    port (
+        clk             : in  std_logic;
+        rst             : in  std_logic;
+        pdi_data        : in  std_logic_vector(W-1 downto 0);
+        pdi_valid       : in  std_logic;
+        pdi_ready       : out std_logic;
+        sdi_data        : in  std_logic_vector(SW-1 downto 0);
+        sdi_valid       : in  std_logic;
+        sdi_ready       : out std_logic;
+        do_data         : out std_logic_vector(W-1 downto 0);
+        do_ready        : in  std_logic;
+        do_valid        : out std_logic;
+        do_last         : out std_logic
+    );
+end LWC_wrapper;
+
+architecture RTL of LWC_wrapper is
+    signal lwc_pdi_data  : std_logic_vector(W-1 downto 0);
+    signal lwc_pdi_valid : std_logic;
+    signal lwc_pdi_ready : std_logic;
+    signal lwc_sdi_data  : std_logic_vector(SW-1 downto 0);
+    signal lwc_sdi_valid : std_logic;
+    signal lwc_sdi_ready : std_logic;
+    signal lwc_do_data   : std_logic_vector(W-1 downto 0);
+    signal lwc_do_ready  : std_logic;
+    signal lwc_do_valid  : std_logic;
+    signal lwc_do_last   : std_logic;
+    
+    signal do_datalast_i : std_logic_vector(W downto 0);
+    signal do_datalast_o : std_logic_vector(W downto 0);
+
+    component LWC
+    port(
+        clk       : in  std_logic;
+        rst       : in  std_logic;
+        pdi_data  : in  std_logic_vector(W - 1 downto 0);
+        pdi_valid : in  std_logic;
+        pdi_ready : out std_logic;
+        sdi_data  : in  std_logic_vector(SW - 1 downto 0);
+        sdi_valid : in  std_logic;
+        sdi_ready : out std_logic;
+        do_data   : out std_logic_vector(W - 1 downto 0);
+        do_ready  : in  std_logic;
+        do_valid  : out std_logic;
+        do_last   : out std_logic
+    );
+    end component LWC;
+
+    -- for all: LWC use entity work.xyz_LWC;
+begin
+
+    assert False report "Using LWC_wrapper" severity warning;
+    
+    LWC_inst : LWC
+        port map(
+            clk       => clk,
+            rst       => rst,
+            pdi_data  => lwc_pdi_data,
+            pdi_valid => lwc_pdi_valid,
+            pdi_ready => lwc_pdi_ready,
+            sdi_data  => lwc_sdi_data,
+            sdi_valid => lwc_sdi_valid,
+            sdi_ready => lwc_sdi_ready,
+            do_data   => lwc_do_data,
+            do_ready  => lwc_do_ready,
+            do_valid  => lwc_do_valid,
+            do_last   => lwc_do_last
+        );
+    
+    elastic_reg_fifo_pdi : entity work.elastic_reg_fifo
+        generic map(
+            W => W
+        )
+        port map(
+            clk       => clk,
+            reset     => rst,
+            in_data   => pdi_data,
+            in_valid  => pdi_valid,
+            in_ready  => pdi_ready,
+            out_data  => lwc_pdi_data,
+            out_valid => lwc_pdi_valid,
+            out_ready => lwc_pdi_ready
+        );
+
+    
+    elastic_reg_fifo_sdi : entity work.elastic_reg_fifo
+        generic map(
+            W => SW
+        )
+        port map(
+            clk       => clk,
+            reset     => rst,
+            in_data   => sdi_data,
+            in_valid  => sdi_valid,
+            in_ready  => sdi_ready,
+            out_data  => lwc_sdi_data,
+            out_valid => lwc_sdi_valid,
+            out_ready => lwc_sdi_ready
+        );
+        
+    elastic_reg_fifo_do : entity work.elastic_reg_fifo
+        generic map(
+            W => W+1
+        )
+        port map(
+            clk       => clk,
+            reset     => rst,
+            in_data   => do_datalast_i,
+            in_valid  => lwc_do_valid,
+            in_ready  => lwc_do_ready,
+            out_data  => do_datalast_o,
+            out_valid => do_valid,
+            out_ready => do_ready
+        );
+        
+    do_datalast_i <= lwc_do_last & lwc_do_data;
+    do_last <= do_datalast_o(W);
+    do_data <= do_datalast_o(W-1 downto 0);   
+    
+end architecture;

--- a/hardware/LWC_rtl/PostProcessor.vhd
+++ b/hardware/LWC_rtl/PostProcessor.vhd
@@ -51,7 +51,7 @@ entity PostProcessor is
             bdo_valid       : in  std_logic;
             bdo_ready       : out std_logic;
             end_of_block    : in  std_logic;
---            bdo_type        : in  std_logic_vector(3 downto 0); -- not used atm
+            bdo_type        : in  std_logic_vector(3 downto 0); -- not used atm
             bdo_valid_bytes : in  std_logic_vector(CCWdiv8-1 downto 0);
             msg_auth        : in  std_logic;
             msg_auth_ready  : out std_logic;
@@ -69,17 +69,20 @@ entity PostProcessor is
 
 end PostProcessor;
 
-architecture PostProcessor of PostProcessor is
+architecture RTL of PostProcessor is
 
     --Signals
     signal do_data_internal     : std_logic_vector(G_W-1 downto 0);
     signal do_valid_internal    : std_logic;
+    signal cmd_ready_internal   : std_logic;
     signal bdo_cleared          : std_logic_vector(CCW-1 downto 0);
     signal len_SegLenCnt        : std_logic;
     signal en_SegLenCnt         : std_logic;
     signal dout_SegLenCnt       : std_logic_vector(15 downto 0);
     signal load_SegLenCnt       : std_logic_vector(15 downto 0);
     signal last_flit_of_segment : std_logic;
+    signal do_fire              : boolean;
+    signal cmd_fire             : boolean;
 
 
     --Registers
@@ -122,7 +125,7 @@ architecture PostProcessor of PostProcessor is
                     S_HDR_MSGLEN_MSB, S_HDR_MSGLEN_LSB, S_OUT_MSG, S_HDR_TAG,
                     S_HDR_RESTAG, S_HDR_TAGLEN_MSB, S_HDR_TAGLEN_LSB, S_OUT_TAG,
                     S_VER_TAG_IN, S_STATUS_FAIL, S_STATUS_SUCCESS
-                );                           
+                );
 
 
 begin
@@ -132,7 +135,7 @@ begin
 
     -- make sure we do not output intermeadiate data
     do_valid <= do_valid_internal;
-    do_data  <= do_data_internal when (do_valid_internal='1') else do_data_defaults;
+    do_data  <= do_data_internal when do_valid_internal = '1' else do_data_defaults;
 
 
     --! Segment Length Counter
@@ -145,6 +148,7 @@ begin
                 port map
                         (
                         clk     => clk,
+                        -- rst     => rst,
                         len     => len_SegLenCnt,
                         ena     => en_SegLenCnt,
                         load    => load_SegLenCnt,
@@ -164,10 +168,14 @@ begin
     end process;
 
 
-
-   -- ====================================================================================================
-   --! 32 bit specific FSM -------------------------------------------------------------------------------
-   -- ====================================================================================================
+    do_fire    <= do_valid_internal = '1' and do_ready = '1';
+    cmd_fire   <= cmd_valid = '1' and cmd_ready_internal = '1';
+    cmd_ready  <= cmd_ready_internal;
+    
+    
+    -- ====================================================================================================
+    --! 32 bit specific FSM -------------------------------------------------------------------------------
+    -- ====================================================================================================
 
 FSM_32BIT: if (G_W=32) generate
 
@@ -180,315 +188,291 @@ FSM_32BIT: if (G_W=32) generate
     --sipo
     signal bdo_valid_p              : std_logic;
     signal bdo_ready_p              : std_logic;
+    signal bdo_p_fire               : boolean;    
     signal bdo_p                    : std_logic_vector(31 downto 0);
 
     signal nx_state, pr_state       : t_state32;
 
     begin
 
-    load_SegLenCnt       <= cmd_seg_length;
-
-    --! SIPO
-    -- for ccw < W: a sipo is used for width conversion
-    bdoSIPO: entity work.DATA_SIPO(behavioral)
-	    generic map(
-	    		G_ASYNC_RSTN => G_ASYNC_RSTN
-	    	)
-	    port map
-	        (
-	            clk          => clk,
-	            rst          => rst,
-	            
-	            -- no need for conversion, as our last serial_in element is also the
-	            -- last parallel_out element
-	            end_of_input => end_of_block,
-	            -- end_of_bock should only be evaluated if bdo_valid_p = '1'
-	
-	            data_p       => bdo_p,
-	            data_valid_p => bdo_valid_p,
-	            data_ready_p => bdo_ready_p,
-	            
-	            data_s       => bdo_cleared,
-	            data_valid_s => bdo_valid,
-	            data_ready_s => bdo_ready
-	        );
-
-    --! State register
-    GEN_proc_SYNC_RST: if (not G_ASYNC_RSTN) generate
-        process (clk)
-        begin
-            if rising_edge(clk) then
-                if(rst='1')  then
+        load_SegLenCnt       <= cmd_seg_length;
+    
+        --! SIPO
+        -- for ccw < W: a sipo is used for width conversion
+        bdoSIPO: entity work.DATA_SIPO(behavioral)
+    	    generic map(
+    	    		G_ASYNC_RSTN => G_ASYNC_RSTN
+    	    	)
+    	    port map
+    	        (
+    	            clk          => clk,
+    	            rst          => rst,
+    	            
+    	            -- no need for conversion, as our last serial_in element is also the
+    	            -- last parallel_out element
+    	            end_of_input => end_of_block,
+    	            -- end_of_bock should only be evaluated if bdo_valid_p = '1'
+    	
+    	            data_p       => bdo_p,
+    	            data_valid_p => bdo_valid_p,
+    	            data_ready_p => bdo_ready_p,
+    	            
+    	            data_s       => bdo_cleared,
+    	            data_valid_s => bdo_valid,
+    	            data_ready_s => bdo_ready
+    	        );
+    
+        --! State register
+        GEN_proc_SYNC_RST: if (not G_ASYNC_RSTN) generate
+            process (clk)
+            begin
+                if rising_edge(clk) then
+                    if(rst='1')  then
+                        pr_state <= S_INIT;
+                    else
+                        pr_state <= nx_state;
+                    end if;
+                end if;
+            end process;
+        end generate GEN_proc_SYNC_RST;
+        GEN_proc_ASYNC_RSTN: if (G_ASYNC_RSTN) generate
+            process (clk, rst)
+            begin
+                if(rst='0')  then
                     pr_state <= S_INIT;
-                else
+                elsif rising_edge(clk) then
                     pr_state <= nx_state;
                 end if;
-            end if;
-        end process;
-    end generate GEN_proc_SYNC_RST;
-    GEN_proc_ASYNC_RSTN: if (G_ASYNC_RSTN) generate
-        process (clk, rst)
+            end process;
+        end generate GEN_proc_ASYNC_RSTN;
+        
+        
+        bdo_p_fire <= bdo_valid_p = '1' and bdo_ready_p = '1';
+        
+    
+    
+        --! Next state function
+        process (pr_state, bdo_p_fire, do_fire, end_of_block, decrypt, cmd_fire,
+            msg_auth_valid, msg_auth, last_flit_of_segment, cmd_opcode, eot)
+    
         begin
-            if(rst='0')  then
-                pr_state <= S_INIT;
-            elsif rising_edge(clk) then
-                pr_state <= nx_state;
-            end if;
-        end process;
-    end generate GEN_proc_ASYNC_RSTN;
-
-
-    --! Next state function
-    process (pr_state, bdo_valid_p, do_ready, end_of_block, decrypt,
-            cmd_valid, msg_auth_valid, msg_auth, last_flit_of_segment,
-            cmd_opcode, eot)
-
-    begin
-        case pr_state is
-
-            when S_INIT =>
-                if (cmd_valid = '1') then
-                    if (cmd_opcode = INST_HASH) then
-                        nx_state <= S_HDR_HASH_VALUE;
-                    else
-                        nx_state <= S_HDR_MSG;
-                    end if;
-                else
-                    nx_state <= S_INIT;
-                end if;
-
-           --Hash
-           when S_HDR_HASH_VALUE =>
-                if (do_ready = '1') then
-                    nx_state <= S_OUT_HASH_VALUE;
-                else
-                    nx_state <= S_HDR_HASH_VALUE;
-                end if;
-
-           when S_OUT_HASH_VALUE =>
-                if (bdo_valid_p = '1' and do_ready = '1' and end_of_block = '1') then
-                    nx_state <= S_STATUS_SUCCESS;
-                else
-                    nx_state <= S_OUT_HASH_VALUE;
-                end if;
-
-            --MSG
-            when S_HDR_MSG =>
-                if (cmd_valid = '1' and do_ready = '1') then
-                    if (cmd_seg_length = x"0000") then
-                        if (decrypt='1') then
-                            nx_state <= S_VER_TAG;
+            nx_state <= pr_state;
+            
+            case pr_state is
+    
+                when S_INIT =>
+                    if cmd_fire then
+                        if cmd_opcode = INST_HASH then
+                            nx_state <= S_HDR_HASH_VALUE;
                         else
-                            nx_state <= S_HDR_TAG;
+                            nx_state <= S_HDR_MSG;
                         end if;
-                    else
-                        nx_state <= S_OUT_MSG;
                     end if;
-                else
-                    nx_state <= S_HDR_MSG;
-                end if;
-
-            when S_OUT_MSG =>
-                if (bdo_valid_p = '1' and do_ready = '1') then
-                    -- This line is needed, if the input (and therefore) the
-                    -- output is splitted in multiple segments.
-                    if (last_flit_of_segment = '1') then
-                    -- This line can be used instead, if there is only one 
-                    -- input segment and there is no ciphertext expansion.
-                    -- This saves us the output counter.
-                    --if (end_of_block = '1') then
-                        
-                        -- this is the last segment
-                        if (eot = '1') then
-                            if (decrypt = '1') then
+    
+               --Hash
+               when S_HDR_HASH_VALUE =>
+                    if do_fire then
+                        nx_state <= S_OUT_HASH_VALUE;
+                    end if;
+    
+               when S_OUT_HASH_VALUE =>
+                    if bdo_p_fire and do_fire and end_of_block = '1' then
+                        nx_state <= S_STATUS_SUCCESS;
+                    end if;
+    
+                --MSG
+                when S_HDR_MSG =>
+                    if cmd_fire and do_fire then
+                        if cmd_seg_length = x"0000" then
+                            if (decrypt='1') then
                                 nx_state <= S_VER_TAG;
                             else
                                 nx_state <= S_HDR_TAG;
                             end if;
                         else
-                            -- this is not the last segment, we have multiple segments
-                            nx_state <= S_HDR_MSG;
+                            nx_state <= S_OUT_MSG;
                         end if;
-                    else
-                        -- more output in current segment
-                        nx_state <= S_OUT_MSG;
                     end if;
-                else
-                    nx_state <= S_OUT_MSG;
-                end if;
-
-            --TAG
-            when S_HDR_TAG =>
-                if (do_ready = '1') then
-                    nx_state <= S_OUT_TAG;
-                else
-                    nx_state <= S_HDR_TAG;
-                end if;
-
-            when S_OUT_TAG =>
-                if (bdo_valid_p = '1' and end_of_block='1' and do_ready='1') then
-                    nx_state <= S_STATUS_SUCCESS;
-                else
-                    nx_state <= S_OUT_TAG;
-                end if;
-
-            when S_VER_TAG =>
-                if (msg_auth_valid = '1') then
-                    if (msg_auth = '1') then
+    
+                when S_OUT_MSG =>
+                    if bdo_p_fire and do_fire then
+                        -- This line is needed, if the input (and therefore) the
+                        -- output is splitted in multiple segments.
+                        if (last_flit_of_segment = '1') then
+                        -- This line can be used instead, if there is only one 
+                        -- input segment and there is no ciphertext expansion.
+                        -- This saves us the output counter.
+                        --if (end_of_block = '1') then
+                            
+                            -- this is the last segment
+                            if (eot = '1') then
+                                if (decrypt = '1') then
+                                    nx_state <= S_VER_TAG;
+                                else
+                                    nx_state <= S_HDR_TAG;
+                                end if;
+                            else
+                                -- this is not the last segment, we have multiple segments
+                                nx_state <= S_HDR_MSG;
+                            end if;
+                        end if;
+                    end if;
+    
+                --TAG
+                when S_HDR_TAG =>
+                    if do_fire then
+                        nx_state <= S_OUT_TAG;
+                    end if;
+    
+                when S_OUT_TAG =>
+                    if bdo_p_fire and end_of_block='1' and do_fire then
                         nx_state <= S_STATUS_SUCCESS;
-                    else
-                        nx_state <= S_STATUS_FAIL;
                     end if;
-                else
-                    nx_state <= S_VER_TAG;
-                end if;
-
-            -- STATUS
-            when S_STATUS_FAIL =>
-                if (do_ready = '1') then
-                    nx_state <= S_INIT;
-                else
-                    nx_state <= S_STATUS_FAIL;
-                end if;
-
-            when S_STATUS_SUCCESS =>
-                if (do_ready = '1') then
-                    nx_state <= S_INIT;
-                else
-                    nx_state <= S_STATUS_SUCCESS;
-                end if;
-
-            when others=>
-                nx_state <= pr_state;
-        end case;
-    end process;
-
-
-    --! Output state function
-    process(pr_state, bdo_valid_p, bdo_p, decrypt, eot, cmd, cmd_valid, do_ready)
-    begin
-            -- DEFAULT SIGNALS
-            -- external interface
-            do_last           <='0';
-            do_data_internal  <= (others => '-');
-            do_valid_internal <='0';
-            -- CryptoCore
-            bdo_ready_p       <='0';
-            msg_auth_ready    <='0';
-            -- Header-FIFO
-            cmd_ready         <='0';
-            -- Segment counter
-            len_SegLenCnt     <='0';
-            en_SegLenCnt      <='0';
-            -- Registers
-            nx_decrypt        <= decrypt;
-            nx_eot            <= eot;
-
-        case pr_state is
-            when S_INIT =>
-
-                if (cmd_valid = '1') then
-                    -- We reiceive either INST_HASH, or INST_ENC or INST_DEC
-                    -- The LSB of INST_ENC and INST_DEC is '1' for Decryption
-                    -- For Hash, this bit is '0', however we never evaluate
-                    -- "decrypt" for Hash.
-                    nx_decrypt <= cmd(28);
-                end if;
-
-                cmd_ready <= '1';
-
-            --MSG
-            when S_HDR_MSG =>
-                cmd_ready          <= do_ready;
-                len_SegLenCnt      <= do_ready and cmd_valid;
-                do_valid_internal  <= cmd_valid;
-                -- preserve EOT flag to support multi segment MSGs
-                nx_eot             <= cmd(25);
-
-                if (decrypt = '1') then
-                    -- header is plaintext
-                    do_data_internal_opcode   <= HDR_PT;
-
-                    -- last: no TAG is sent after decryption.
-                    -- If cmd(25) = '0' (EOT ='0') then we have multiple segments,
-                    -- and this is not the last one.
-                    do_data_internal_flags(0) <= '1' AND cmd(25);
-                else
-                    -- header is ciphertext
-                    do_data_internal_opcode   <= HDR_CT;
-                    -- last: we will send a TAG afterwards, this is never
-                    -- the last segment.
-                    do_data_internal_flags(0) <= '0';
-                end if;
-
-                do_data_internal_flags(3) <= '0';      -- Partial = '0',
-                -- XXX: The definition for EOI is not intuitive for data out.
-                --      At the moment, EOI is defined to be '0'.
-                --      However, this might be change to '1' in the future!
-                do_data_internal_flags(2) <= '0';      --EOI
-                do_data_internal_flags(1) <=  cmd(25); --EOT
-
-                -- reserved not used.
-                do_data_internal_reserved <= (others => '0');
-                -- length forwarded from the cmd FIFO
-                do_data_internal_length   <= cmd(15 downto 0);
-
-            when S_OUT_MSG =>
-                bdo_ready_p       <= do_ready;
-                do_valid_internal <= bdo_valid_p;
+    
+                when S_VER_TAG =>
+                    if msg_auth_valid = '1' then
+                        if msg_auth = '1' then
+                            nx_state <= S_STATUS_SUCCESS;
+                        else
+                            nx_state <= S_STATUS_FAIL;
+                        end if;
+                    end if;
+    
+                -- STATUS
+                when S_STATUS_FAIL =>
+                    if do_fire then
+                        nx_state <= S_INIT;
+                    end if;
+    
+                when S_STATUS_SUCCESS =>
+                    if do_fire then
+                        nx_state <= S_INIT;
+                    end if;
+    
+            end case;
+        end process;
+    
+    
+        --! Output state function
+        process(pr_state, bdo_valid_p, bdo_p, decrypt, eot, cmd, cmd_valid, do_ready)
+        begin
+                -- DEFAULT SIGNALS
+                -- external interface
+                do_last           <= '0';
                 do_data_internal  <= bdo_p;
-                en_SegLenCnt      <= bdo_valid_p and do_ready;
-
-            --TAG
-            when S_HDR_TAG =>
-                do_valid_internal         <= '1';
-                do_data_internal_opcode   <= HDR_TAG;
-                -- Partial = '0', EOI ='0', EOT = '1', Last = '1':
-                -- No tag is larger than 2^(16-1) bytes
-                do_data_internal_flags    <= "0011";
-                do_data_internal_reserved <= (others => '0'); --reserved not used.
-                do_data_internal_length   <= std_logic_vector(to_unsigned(TAGdiv8, 16));
-
-            when S_OUT_TAG =>
-                bdo_ready_p       <= do_ready;
-                do_valid_internal <= bdo_valid_p;
-                do_data_internal  <= bdo_p;
-
-            when S_VER_TAG =>
-                msg_auth_ready <= '1';
-
-            --HASH-VALUE
-            when S_HDR_HASH_VALUE =>
-                do_valid_internal         <= '1';
-                do_data_internal_opcode   <= HDR_HASH_VALUE;
-                -- Partial = '0', EOI ='0', EOT = '1', LAST = '1':
-                -- No tag is larger than 2^(16-1) bytes
-                do_data_internal_flags    <= "0011";
-                do_data_internal_reserved <= (others => '0'); -- reserved not used
-                do_data_internal_length   <= std_logic_vector(to_unsigned(HASHdiv8, 16));
-
-            when S_OUT_HASH_VALUE =>
-                bdo_ready_p       <= do_ready;
-                do_valid_internal <= bdo_valid_p;
-                do_data_internal  <= bdo_p;
-
-            --STATUS
-            when S_STATUS_FAIL =>
-                do_valid_internal             <= '1';
-                -- do_last must only be asserted together with do_valid(_internal)
-                do_last                       <= '1';
-                do_data_internal_opcode       <= INST_FAILURE;
-                do_data_internal(27 downto 0) <= (others=>'0');
-
-            when S_STATUS_SUCCESS =>
-                do_valid_internal             <= '1';
-                -- do_last must only be asserted together with do_valid(_internal)
-                do_last                       <= '1';
-                do_data_internal_opcode       <= INST_SUCCESS;
-                do_data_internal(27 downto 0) <= (others=>'0');
-
-        end case;
-    end process;
+                do_valid_internal <= '0';
+                -- CryptoCore
+                bdo_ready_p       <= '0';
+                msg_auth_ready    <= '0';
+                -- Header-FIFO
+                cmd_ready_internal <= '0';
+                -- Segment counter
+                len_SegLenCnt     <= '0';
+                en_SegLenCnt      <= '0';
+                -- Registers
+                nx_decrypt        <= decrypt;
+                nx_eot            <= eot;
+    
+            case pr_state is
+                when S_INIT =>
+                    if (cmd_valid = '1') then
+                        -- We reiceive either INST_HASH, or INST_ENC or INST_DEC
+                        -- The LSB of INST_ENC and INST_DEC is '1' for Decryption
+                        -- For Hash, this bit is '0', however we never evaluate
+                        -- "decrypt" for Hash.
+                        nx_decrypt <= cmd(28);
+                    end if;
+                    cmd_ready_internal <= '1';
+    
+                --MSG
+                when S_HDR_MSG =>
+                    cmd_ready_internal <= do_ready;
+                    len_SegLenCnt      <= do_ready and cmd_valid;
+                    do_valid_internal  <= cmd_valid;
+                    -- preserve EOT flag to support multi segment MSGs
+                    nx_eot             <= cmd(25);
+    
+                    if (decrypt = '1') then
+                        -- header is plaintext
+                        do_data_internal_opcode   <= HDR_PT;
+    
+                        -- last: no TAG is sent after decryption.
+                        -- If cmd(25) = '0' (EOT ='0') then we have multiple segments,
+                        -- and this is not the last one.
+                        do_data_internal_flags(0) <= '1' AND cmd(25);
+                    else
+                        -- header is ciphertext
+                        do_data_internal_opcode   <= HDR_CT;
+                        -- last: we will send a TAG afterwards, this is never
+                        -- the last segment.
+                        do_data_internal_flags(0) <= '0';
+                    end if;
+    
+                    do_data_internal_flags(3) <= '0';      -- Partial = '0',
+                    -- XXX: The definition for EOI is not intuitive for data out.
+                    --      At the moment, EOI is defined to be '0'.
+                    --      However, this might be changed to '1' in the future! ??? FIXME
+                    do_data_internal_flags(2) <= '0';      --EOI
+                    do_data_internal_flags(1) <=  cmd(25); --EOT
+    
+                    -- reserved not used.
+                    do_data_internal_reserved <= (others => '0');
+                    -- length forwarded from the cmd FIFO
+                    do_data_internal_length   <= cmd(15 downto 0);
+    
+                when S_OUT_MSG =>
+                    bdo_ready_p       <= do_ready;
+                    do_valid_internal <= bdo_valid_p;
+                    en_SegLenCnt      <= bdo_valid_p and do_ready;
+    
+                --TAG
+                when S_HDR_TAG =>
+                    do_valid_internal         <= '1';
+                    do_data_internal_opcode   <= HDR_TAG;
+                    -- Partial = '0', EOI ='0', EOT = '1', Last = '1':
+                    -- No tag is larger than 2^(16-1) bytes
+                    do_data_internal_flags    <= "0011";
+                    do_data_internal_reserved <= (others => '0'); --reserved not used.
+                    do_data_internal_length   <= std_logic_vector(to_unsigned(TAGdiv8, 16));
+    
+                when S_OUT_TAG =>
+                    bdo_ready_p       <= do_ready;
+                    do_valid_internal <= bdo_valid_p;
+    
+                when S_VER_TAG =>
+                    msg_auth_ready <= '1';
+    
+                --HASH-VALUE
+                when S_HDR_HASH_VALUE =>
+                    do_valid_internal         <= '1';
+                    do_data_internal_opcode   <= HDR_HASH_VALUE;
+                    -- Partial = '0', EOI ='0', EOT = '1', LAST = '1':
+                    -- No tag is larger than 2^(16-1) bytes
+                    do_data_internal_flags    <= "0011";
+                    do_data_internal_reserved <= (others => '0'); -- reserved not used
+                    do_data_internal_length   <= std_logic_vector(to_unsigned(HASHdiv8, 16));
+    
+                when S_OUT_HASH_VALUE =>
+                    bdo_ready_p       <= do_ready;
+                    do_valid_internal <= bdo_valid_p;
+    
+                --STATUS
+                when S_STATUS_FAIL =>
+                    do_valid_internal             <= '1';
+                    -- do_last must only be asserted together with do_valid(_internal)
+                    do_last                       <= '1';
+                    do_data_internal_opcode       <= INST_FAILURE;
+                    do_data_internal(27 downto 0) <= (others => '0');
+    
+                when S_STATUS_SUCCESS =>
+                    do_valid_internal             <= '1';
+                    -- do_last must only be asserted together with do_valid(_internal)
+                    do_last                       <= '1';
+                    do_data_internal_opcode       <= INST_SUCCESS;
+                    do_data_internal(27 downto 0) <= (others => '0');
+    
+            end case;
+        end process;
 
 end generate;
 
@@ -681,7 +665,7 @@ FSM_16BIT: if (G_W=16) generate
         bdo_ready         <='0';
         msg_auth_ready    <='0';
         -- Header-FIFO
-        cmd_ready         <='0';
+        cmd_ready_internal         <='0';
         -- Segment counter
         len_SegLenCnt     <='0';
         en_SegLenCnt      <='0';
@@ -695,7 +679,7 @@ FSM_16BIT: if (G_W=16) generate
                 if (cmd_valid = '1') then
                     nx_decrypt <= cmd(G_W-4);
                 end if;
-                cmd_ready <= '1';
+                cmd_ready_internal <= '1';
                 nx_eot    <= '0';
 
             --HASH
@@ -718,7 +702,7 @@ FSM_16BIT: if (G_W=16) generate
 
             --MSG
             when S_HDR_MSG =>
-                cmd_ready         <= do_ready;
+                cmd_ready_internal         <= do_ready;
                 do_valid_internal <= cmd_valid;
                 len_SegLenCnt     <= do_ready and cmd_valid;
                 nx_eot            <= cmd(G_W-7);
@@ -739,7 +723,7 @@ FSM_16BIT: if (G_W=16) generate
                 do_data_internal(G_W-1-(G_W/8)*4 downto 0) <= cmd(G_W-1-(G_W/8)*4 downto 0);
 
             when S_HDR_MSGLEN =>
-                cmd_ready          <= do_ready;
+                cmd_ready_internal          <= do_ready;
                 len_SegLenCnt      <= do_ready and cmd_valid;
                 do_valid_internal  <= cmd_valid;
                 do_data_internal   <= cmd;
@@ -794,12 +778,12 @@ FSM_8BIT: if (G_W=8) generate
 
     --! 8 Bit specific declarations
     signal HDR_TAG_internal     : std_logic_vector(31 downto 0);
-    signal data_seg_length      : std_logic_vector(G_W-1 downto 0);
-    signal tag_size_bytes       : std_logic_vector(16  -1 downto 0);
-    signal do_data_t16          : std_logic_vector(16  -1 downto 0);
+    signal data_seg_length      : std_logic_vector(G_W - 1 downto 0);
+    signal tag_size_bytes       : std_logic_vector(16  - 1 downto 0);
+    signal do_data_t16          : std_logic_vector(16  - 1 downto 0);
     --Registers
     signal nx_state, pr_state: t_state8;
-    signal dout_LenReg, nx_dout_LenReg : std_logic_vector(8   -1 downto 0);
+    signal dout_LenReg, nx_dout_LenReg : std_logic_vector(8 - 1 downto 0);
 
     
     begin
@@ -1032,7 +1016,7 @@ FSM_8BIT: if (G_W=8) generate
         bdo_ready          <='0';
         msg_auth_ready     <='0';
         --Header/tag-FIFO
-        cmd_ready          <='0';
+        cmd_ready_internal          <='0';
         -- Segment counter
         len_SegLenCnt      <='0';
         en_SegLenCnt       <='0';
@@ -1047,7 +1031,7 @@ FSM_8BIT: if (G_W=8) generate
                 if (cmd_valid = '1') then
                     nx_decrypt <= cmd(G_W-4);
                 end if;
-                cmd_ready <= '1';
+                cmd_ready_internal <= '1';
                 nx_eot    <= '0';
 
             --HASH
@@ -1076,7 +1060,7 @@ FSM_8BIT: if (G_W=8) generate
 
             --!MSG/CT
             when S_HDR_MSG =>
-                cmd_ready          <= do_ready;
+                cmd_ready_internal          <= do_ready;
                 do_valid_internal  <= cmd_valid;
                 len_SegLenCnt      <= do_ready and cmd_valid;
                 nx_eot             <= cmd(G_W-7);
@@ -1094,12 +1078,12 @@ FSM_8BIT: if (G_W=8) generate
                 do_data_internal(G_W-7) <= cmd(G_W-7);
 
             when S_HDR_RESMSG =>
-                cmd_ready         <= do_ready;
+                cmd_ready_internal         <= do_ready;
                 do_valid_internal <= cmd_valid;
                 do_data_internal  <= cmd;
 
             when S_HDR_MSGLEN_MSB =>
-                cmd_ready         <= do_ready;
+                cmd_ready_internal         <= do_ready;
                 if ((do_ready = '1') and (cmd_valid = '1')) then
                     nx_dout_LenReg  <= data_seg_length(G_W-1 downto G_W-8);
                 end if;
@@ -1107,7 +1091,7 @@ FSM_8BIT: if (G_W=8) generate
                 do_data_internal  <= cmd;
 
             when S_HDR_MSGLEN_LSB =>
-                cmd_ready         <= do_ready;
+                cmd_ready_internal         <= do_ready;
                 len_SegLenCnt     <= do_ready and cmd_valid;
                 do_valid_internal <= cmd_valid;
                 do_data_internal  <= cmd;
@@ -1160,4 +1144,4 @@ FSM_8BIT: if (G_W=8) generate
 
 end generate;
 
-end PostProcessor;
+end architecture RTL;

--- a/hardware/LWC_rtl/elastic_reg_fifo.vhd
+++ b/hardware/LWC_rtl/elastic_reg_fifo.vhd
@@ -1,0 +1,96 @@
+--------------------------------------------------------------------------------
+--! @file       elastic_reg_fifo.vhd
+--! @brief      Reg-based 2-level elastic FIFO for breaking combinational paths
+--!                while maintaining full data rate
+--! @author     Kamyar Mohajerani (kamyar <at> ieee.org)
+--! @copyright  Copyright (c) 2020 Cryptographic Engineering Research Group
+--!             ECE Department, George Mason University Fairfax, VA, U.S.A.
+--!             All rights Reserved.
+--! @license    This project is released under the GNU Public License.
+--!             The license and distribution terms for this file may be
+--!             found in the file LICENSE in this distribution or at
+--!             http://www.gnu.org/licenses/gpl-3.0.txt
+--!
+--------------------------------------------------------------------------------
+--! Description
+--!  Minimal FIFO with no combinational path from inputs to outputs
+--!   composed of a pipelined FIFO (fifo0) and a bypassing FIFO (fifo1).
+--!   The pipelined FIFO can enque incoming data when full but can't deque while empty
+--!   The bypassing FIFO can deque incoming data when empty but can't enque while full
+--------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity elastic_reg_fifo is
+    generic (
+        W: integer
+    );
+    port (
+        clk       : in  std_logic;
+        reset     : in  std_logic;
+        in_data   : in  std_logic_vector(W-1 downto 0); 
+        in_valid  : in  std_logic;
+        in_ready  : out std_logic;
+        out_data  : out std_logic_vector(W-1 downto 0); 
+        out_valid : out std_logic;
+        out_ready : in  std_logic
+    );
+end entity;
+
+architecture rtl of elastic_reg_fifo is
+    -- registers
+    signal fifo0_data, fifo1_data : std_logic_vector(W-1 downto 0);
+    signal fifo0_is_full, fifo1_is_full       : std_logic;
+
+    -- wires
+    signal fifo0_in_ready, fifo1_can_enq: std_logic;
+begin
+
+    
+    -- FIFO_0: pipelined (can enque even when full and output is ready)
+    in_ready <= fifo0_in_ready;
+    fifo0_in_ready <= (not fifo0_is_full) or fifo1_can_enq; -- either not full or out is ready
+    -- fifo0_out_valid <= v0; -- but can dequeue only when not empty
+
+    process (clk)
+    begin
+        if rising_edge(clk) then
+            if reset = '1' then
+                fifo0_is_full <= '0';
+            else
+                if fifo0_in_ready = '1' then -- can store
+                    fifo0_is_full <= in_valid;
+                    if in_valid = '1' then
+                        fifo0_data <= in_data;
+                    end if;
+                end if;
+            end if;
+        end if;
+    end process;
+
+
+    -- FIFO_1: bypassing (can dequeue even if empty and input is valid)
+    out_data  <= fifo1_data when fifo1_is_full = '1' else fifo0_data;
+    out_valid <= fifo0_is_full or fifo1_is_full; -- can dequeue input valid or full
+    fifo1_can_enq <= not fifo1_is_full;          -- can enque only when not full
+
+    process (clk)
+    begin
+        if rising_edge(clk) then
+            if reset = '1' then
+                fifo1_is_full <= '0';
+            else
+                if out_ready = '0' then -- can't bypass
+                    if fifo1_is_full = '0' and fifo0_is_full = '1' then -- will enqueue without bypass (store)
+                        fifo1_data <= fifo0_data;
+                        fifo1_is_full <= '1';
+                    end if;
+                else -- deque
+                    fifo1_is_full <= '0';
+                end if;
+            end if;
+        end if;
+    end process;
+
+end architecture;

--- a/hardware/LWC_rtl/key_piso.vhd
+++ b/hardware/LWC_rtl/key_piso.vhd
@@ -30,10 +30,6 @@ use work.design_pkg.all;
 use work.NIST_LWAPI_pkg.all;
 
 entity KEY_PISO is 
-	generic (
-        G_SW         : integer;
-        G_ASYNC_RSTN : boolean
-	);
     port(
 
         clk                : in std_logic;
@@ -43,7 +39,7 @@ entity KEY_PISO is
         data_valid_s       : out STD_LOGIC;
         data_ready_s       : in  STD_LOGIC;
 
-        data_p             : in  STD_LOGIC_VECTOR(G_SW-1 downto 0);
+        data_p             : in  STD_LOGIC_VECTOR(SW-1 downto 0);
         data_valid_p       : in  STD_LOGIC;
         data_ready_p       : out STD_LOGIC
 
@@ -66,7 +62,7 @@ begin
     assert (CCSW = 8) OR (CCSW = 16) or (CCSW=32) report "This module only supports CCSW={8,16,32}!" severity failure;
 
 CCSW8_16: if CCSW /= 32 generate
-    GEN_proc_SYNC_RST: if (not G_ASYNC_RSTN) generate
+    GEN_proc_SYNC_RST: if (not ASYNC_RSTN) generate
         process (clk)
         begin
             if rising_edge(clk) then
@@ -78,7 +74,7 @@ CCSW8_16: if CCSW /= 32 generate
             end if;
         end process;
     end generate GEN_proc_SYNC_RST;
-    GEN_proc_ASYNC_RSTN: if (G_ASYNC_RSTN) generate
+    GEN_proc_ASYNC_RSTN: if (ASYNC_RSTN) generate
         process (clk, rst)
         begin
             if(rst='0')  then

--- a/hardware/LWC_tb/LWC_TB.vhd
+++ b/hardware/LWC_tb/LWC_TB.vhd
@@ -17,24 +17,22 @@
 -------------------------------------------------------------------------------
 
 library ieee;
-use ieee.std_logic_1164.ALL;
+use ieee.std_logic_1164.all;
 use ieee.numeric_std.all;
-
 use std.textio.all;
 
-use work.LWC_TB_compatibility_pkg.all;
+use work.LWC_TB_pkg.all;
 use work.NIST_LWAPI_pkg.all;
-
 
 entity LWC_TB IS
     generic (
         G_MAX_FAILURES      : integer := 100;
         G_TEST_MODE         : integer := 0;
-        G_TEST_IPSTALL      : integer := 10;
-        G_TEST_ISSTALL      : integer := 100;
-        G_TEST_OSTALL       : integer := 40;
-        G_LOG2_FIFODEPTH    : integer := 8;
-        G_PERIOD            : time    := 10 ns;
+        G_TEST_IPSTALL      : integer := 3;
+        G_TEST_ISSTALL      : integer := 3;
+        G_TEST_OSTALL       : integer := 3;
+        G_RANDOMIZE_STALLS  : boolean := True;
+        G_PERIOD_PS         : integer := 10_000;
         G_FNAME_PDI         : string  := "../KAT/v1/pdi.txt";
         G_FNAME_SDI         : string  := "../KAT/v1/sdi.txt";
         G_FNAME_DO          : string  := "../KAT/v1/do.txt";
@@ -46,14 +44,10 @@ entity LWC_TB IS
     );
 end LWC_TB;
 
-architecture behavior of LWC_TB is
-	
-    --! bus width. 
-    constant G_PWIDTH           : integer := W;
-    constant G_SWIDTH           : integer := SW;
-    -- for automated/scripted testing override:
-    --    W and SW in work.NIST_LWAPI_pkg
-    --    CCW and CCSW in work.design_pkg
+architecture TB of LWC_TB is
+    ------------- timing constants ------------------
+    constant clk_period         : time := G_PERIOD_PS * ps;
+    constant input_delay        : time := 0 ns; -- clk_period / 2; --
 
     --! =================== --
     --! SIGNALS DECLARATION --
@@ -62,82 +56,55 @@ architecture behavior of LWC_TB is
     --! simulation signals (used by ATHENa script, ignore if not used)
     signal simulation_fails     : std_logic := '0';
     signal stop_clock           : boolean   := False;
-
-    --! error check signal
-    signal global_stop          : std_logic := '1';
+    
+    -- reset completed
+    signal reset_done           : boolean   := False;
 
     --! globals
     signal clk                  : std_logic := '0';
-    signal io_clk               : std_logic := '0';
     signal rst                  : std_logic := '0';
 
     --! pdi
-    signal fpdi_din             : std_logic_vector(G_PWIDTH-1 downto 0) := (others => '0');
-    signal fpdi_din_valid       : std_logic := '0';
-    signal fpdi_din_ready       : std_logic;
-    signal fpdi_dout            : std_logic_vector(G_PWIDTH-1 downto 0);
-    signal fpdi_dout_valid      : std_logic;
-    signal fpdi_dout_ready      : std_logic;
-    signal pdi_delayed          : std_logic_vector(G_PWIDTH-1 downto 0);
-    signal pdi_valid            : std_logic;
-    signal pdi_valid_selected   : std_logic;
+    signal pdi_data             : std_logic_vector(W-1 downto 0) := (others => '0');
+    signal pdi_data_delayed     : std_logic_vector(W-1 downto 0) := (others => '0');
+    signal pdi_valid            : std_logic := '0';
+    signal pdi_valid_delayed    : std_logic := '0';
     signal pdi_ready            : std_logic;
 
     --! sdi
-    signal fsdi_din             : std_logic_vector(G_SWIDTH-1 downto 0)
-        := (others=>'0');
-    signal fsdi_din_valid       : std_logic := '0';
-    signal fsdi_din_ready       : std_logic;
-    signal fsdi_dout            : std_logic_vector(G_SWIDTH-1 downto 0);
-    signal fsdi_dout_valid      : std_logic;
-    signal fsdi_dout_ready      : std_logic;
-    signal sdi_delayed          : std_logic_vector(G_SWIDTH-1 downto 0);
-    signal sdi_valid            : std_logic;
-    signal sdi_valid_selected   : std_logic;
+    signal sdi_data             : std_logic_vector(SW-1 downto 0) := (others => '0');
+    signal sdi_data_delayed     : std_logic_vector(SW-1 downto 0) := (others => '0');
+    signal sdi_valid            : std_logic := '0';
+    signal sdi_valid_delayed    : std_logic := '0';
     signal sdi_ready            : std_logic;
 
     --! do
-    signal do                   : std_logic_vector(G_PWIDTH-1 downto 0);
+    signal do_data              : std_logic_vector(W-1 downto 0);
     signal do_valid             : std_logic;
     signal do_last              : std_logic;
-    signal do_ready             : std_logic;
-    signal do_ready_selected    : std_logic;
-    signal fdo_din_ready        : std_logic;
-    signal fdo_din_valid        : std_logic;
-    signal fdo_dout             : std_logic_vector(G_PWIDTH-1 downto 0);
-    signal fdo_dout_valid       : std_logic;
-    signal fdo_dout_ready       : std_logic := '0';
+    signal do_ready             : std_logic := '0';
+    signal do_ready_delayed     : std_logic := '0';
 
     --! Verification signals
-    signal stall_pdi_valid      : std_logic := '0';
-    signal stall_sdi_valid      : std_logic := '0';
-    signal stall_do_full        : std_logic := '0';
     signal stall_msg            : std_logic := '0';
-    constant SUCCESS_WORD       : std_logic_vector(G_PWIDTH - 1 downto 0) := INST_SUCCESS & (G_PWIDTH - 5 downto 0 => '0');
-    constant FAILURE_WORD       : std_logic_vector(G_PWIDTH - 1 downto 0) := INST_FAILURE & (G_PWIDTH - 5 downto 0 => '0');
+    
     --! Measurement signals
     signal clk_cycle_counter    : integer := 0;
     signal latency              : integer := 0;
     signal latency_done         : std_logic := '0';
     signal start_latency_timer  : std_logic := '0';
-    ------------- clock constant ------------------
-    constant clk_period         : time := G_PERIOD;
-    constant io_clk_period      : time := clk_period;
-    ----------- end of clock constant -------------
-
-    ------------- string constant ------------------
-    --! constant
+    signal tv_count             : integer := 0;
+    
+    ------------- constants ------------------
     constant cons_tb            : string(1 to 6) := "# TB :";
     constant cons_ins           : string(1 to 6) := "INS = ";
     constant cons_hdr           : string(1 to 6) := "HDR = ";
     constant cons_dat           : string(1 to 6) := "DAT = ";
     constant cons_stt           : string(1 to 6) := "STT = ";
-
-    --! Shared constant
     constant cons_eof           : string(1 to 6) := "###EOF";
-    ----------- end of string constant -------------
+    constant SUCCESS_WORD       : std_logic_vector(W - 1 downto 0) := INST_SUCCESS & (W - 5 downto 0 => '0');
+    constant FAILURE_WORD       : std_logic_vector(W - 1 downto 0) := INST_FAILURE & (W - 5 downto 0 => '0');
 
-    signal tv_count:integer:=0;
 
     ------------------- input / output files ----------------------
     file pdi_file       : text open read_mode  is G_FNAME_PDI;
@@ -150,263 +117,181 @@ architecture behavior of LWC_TB is
     file result_file    : text open write_mode is G_FNAME_RESULT;
     file failures_file  : text open write_mode is G_FNAME_FAILED_TVS;
     ----------------- end of input / output files -----------------
-	
-	----------------- component decrations ------------------
-	-- LWC is instantiated as component to make mixed-language simulation possible
-	component LWC
-		port(
-			clk       : in  std_logic;
-			rst       : in  std_logic;
-			pdi_data  : in  std_logic_vector(W - 1 downto 0);
-			pdi_valid : in  std_logic;
-			pdi_ready : out std_logic;
-			sdi_data  : in  std_logic_vector(W - 1 downto 0);
-			sdi_valid : in  std_logic;
-			sdi_ready : out std_logic;
-			do_data   : out std_logic_vector(W - 1 downto 0);
-			do_ready  : in  std_logic;
-			do_valid  : out std_logic;
-			do_last   : out std_logic
-		);
-	end component LWC;
-	
+
+    function word_pass(actual: std_logic_vector(W-1 downto 0); expected: std_logic_vector(W-1 downto 0)) return boolean is
+    begin
+        for i in W-1 downto 0 loop
+            if  actual(i) /= expected(i) and expected(i) /= 'X' then
+                return False;
+            end if;
+        end loop;
+        return True;
+    end function word_pass;
+    
+    ----------------- component decrations ------------------
+    -- LWC is instantiated as component to make mixed-language simulation possible
+    component LWC
+        port(
+            clk       : in  std_logic;
+            rst       : in  std_logic;
+            pdi_data  : in  std_logic_vector(W - 1 downto 0);
+            pdi_valid : in  std_logic;
+            pdi_ready : out std_logic;
+            sdi_data  : in  std_logic_vector(SW - 1 downto 0);
+            sdi_valid : in  std_logic;
+            sdi_ready : out std_logic;
+            do_data   : out std_logic_vector(W - 1 downto 0);
+            do_ready  : in  std_logic;
+            do_valid  : out std_logic;
+            do_last   : out std_logic
+        );
+    end component LWC;
+    
 begin
 
     genClk: process
     begin
-        if (not stop_clock and global_stop = '1') then
+        if not stop_clock then
             clk <= '1';
-            wait for clk_period/2;
+            wait for clk_period / 2;
             clk <= '0';
-            wait for clk_period/2;
+            wait for clk_period / 2;
         else
             wait;
         end if;
     end process genClk;
+    
+    -- LWC is instantiated as a component for mixed languages simulation
+  
+    uut: LWC
+    port map(
+        clk          => clk,
+        rst          => rst,
+        pdi_data     => pdi_data_delayed,
+        pdi_valid    => pdi_valid_delayed,
+        pdi_ready    => pdi_ready,
+        sdi_data     => sdi_data_delayed,
+        sdi_valid    => sdi_valid_delayed,
+        sdi_ready    => sdi_ready,
+        do_data      => do_data,
+        do_ready     => do_ready_delayed,
+        do_valid     => do_valid,
+        do_last      => do_last
+    );
+    
+    pdi_data_delayed  <= transport pdi_data  after input_delay;
+    pdi_valid_delayed <= transport pdi_valid after input_delay;
+    sdi_data_delayed  <= transport sdi_data  after input_delay;
+    sdi_valid_delayed <= transport sdi_valid after input_delay;
+    do_ready_delayed  <= transport do_ready  after input_delay;
 
-    genIOclk: process
+    genRst: process
     begin
-        if ((not stop_clock) and (global_stop = '1')) then
-            io_clk <= '1';
-            wait for io_clk_period/2;
-            io_clk <= '0';
-            wait for io_clk_period/2;
+        report LF & " -- Testvectors:  " & G_FNAME_PDI & " " & G_FNAME_SDI & " " & G_FNAME_DO & LF &
+        " -- Clock Period: " & integer'image(G_PERIOD_PS) & " ps" & LF &
+        " -- Test Mode:    " & integer'image(G_TEST_MODE) & LF &
+        " -- Max Failures: " & integer'image(G_MAX_FAILURES) & LF & CR severity note;
+
+        seed(123);
+        wait for 100 ns; -- Xilinx GSR takes 100ns, required for post-synth simulation
+        if ASYNC_RSTN then
+            rst <= '0'; -- @suppress "Dead code"
+            wait for 2 * clk_period;
+            rst <= '1';
         else
-            wait;
+            rst <= '1';
+            wait for 2 * clk_period;
+            rst <= '0';
         end if;
-    end process genIOclk;
-
-    genPDIfifo: entity work.fwft_fifo(structure)
-	    generic map (
-	        G_W          => G_PWIDTH,
-	        G_LOG2DEPTH  => G_LOG2_FIFODEPTH)
-	    port map (
-	        clk          =>  io_clk,
-	        rst          =>  rst,
-	        din          =>  fpdi_din,
-	        din_valid    =>  fpdi_din_valid,
-	        din_ready    =>  fpdi_din_ready,
-	        dout         =>  fpdi_dout,
-	        dout_valid   =>  fpdi_dout_valid,
-	        dout_ready   =>  fpdi_dout_ready
-	    );
-
-    fpdi_dout_ready     <= '0' when (stall_pdi_valid = '1' or stall_msg = '1') else pdi_ready;
-    pdi_valid_selected  <= '0' when (stall_pdi_valid = '1' or stall_msg = '1') else fpdi_dout_valid;
-    pdi_valid           <= pdi_valid_selected after 1/4*clk_period;
-    pdi_delayed         <= fpdi_dout after 1/4*clk_period;
-
-    genSDIfifo: entity work.fwft_fifo(structure)
-	    generic map (
-	        G_W          => G_SWIDTH,
-	        G_LOG2DEPTH  => G_LOG2_FIFODEPTH)
-	    port map (
-	        clk          =>  io_clk,
-	        rst          =>  rst,
-	        din          =>  fsdi_din,
-	        din_valid    =>  fsdi_din_valid,
-	        din_ready    =>  fsdi_din_ready,
-	        dout         =>  fsdi_dout,
-	        dout_valid   =>  fsdi_dout_valid,
-	        dout_ready   =>  fsdi_dout_ready
-	    );
-
-    fsdi_dout_ready     <= '0' when stall_sdi_valid = '1' else sdi_ready;
-    sdi_valid_selected  <= '0' when stall_sdi_valid = '1' else fsdi_dout_valid;
-    sdi_valid           <= sdi_valid_selected after 1/4*clk_period;
-    sdi_delayed         <= fsdi_dout after 1/4*clk_period;
-
-    genDOfifo: entity work.fwft_fifo(structure)
-	    generic map (
-	        G_W          => G_PWIDTH,
-	        G_LOG2DEPTH  => G_LOG2_FIFODEPTH)
-	    port map (
-	        clk          =>  io_clk,
-	        rst          =>  rst,
-	        din          =>  do,
-	        din_valid    =>  fdo_din_valid,
-	        din_ready    =>  fdo_din_ready,
-	        dout         =>  fdo_dout,
-	        dout_valid   =>  fdo_dout_valid,
-	        dout_ready   =>  fdo_dout_ready
-	    );
-
-    fdo_din_valid       <= '0' when stall_do_full = '1' else do_valid;
-    do_ready_selected   <= '0' when stall_do_full = '1' else fdo_din_ready;
-    do_ready            <= do_ready_selected after 1/4*clk_period;
-	
-	-- LWC is instantiated as a component for mixed languages simulation
-	uut: LWC
-		port map(
-	        clk          => clk,
-	        rst          => rst,
-	        pdi_data     => pdi_delayed,
-	        pdi_valid    => pdi_valid,
-	        pdi_ready    => pdi_ready,
-	        sdi_data     => sdi_delayed,
-	        sdi_valid    => sdi_valid,
-	        sdi_ready    => sdi_ready,
-	        do_data      => do,
-	        do_ready     => do_ready,
-	        do_valid     => do_valid,
-	        do_last      => do_last
-		);
-
-
+        wait until rising_edge(clk);
+        wait for clk_period; -- optional
+        reset_done <= True;
+        wait;
+    end process;
+    
     --! =======================================================================
     --! ==================== DATA POPULATION FOR PUBLIC DATA ==================
     tb_read_pdi : process
         variable line_data      : line;
-        variable word_block     : std_logic_vector(G_PWIDTH-1 downto 0)
-            := (others=>'0');
+        variable word_block     : std_logic_vector(W-1 downto 0) := (others=>'0');
         variable read_result    : boolean;
-        variable loop_enable    : std_logic   := '1';
-        variable temp_read      : string(1 to 6);
-        variable valid_line     : boolean     := True;
+        variable line_head      : string(1 to 6);
+        variable stall_cycles   : integer;
     begin
-    	if ASYNC_RSTN then
-	        rst <= '0';               wait for 5*clk_period; -- @suppress "Dead code"
-	        rst <= '1';               wait for clk_period;
-    	else
-	        rst <= '1';               wait for 5*clk_period;
-	        rst <= '0';               wait for clk_period;
-        end if;
 
-        --! read header
-        while ( not endfile (pdi_file)) and ( loop_enable = '1' ) loop
-            if endfile (pdi_file) then
-                loop_enable := '0';
-            end if;
-
+        wait until reset_done;
+        
+        wait until rising_edge(clk);
+        
+        while not endfile(pdi_file) loop
             readline(pdi_file, line_data);
-            read(line_data, temp_read, read_result);
-            if (temp_read = cons_ins) then
-                loop_enable := '0';
+            read(line_data, line_head, read_result); --! read line header
+            if read_result and (line_head = cons_ins) then
+                tv_count <= tv_count + 1;
+            end if;
+            if read_result and (line_head = cons_ins or line_head = cons_hdr or line_head = cons_dat) then
+                loop
+                    LWC_HREAD(line_data, word_block, read_result);
+                    if not read_result then
+                        exit;
+                    end if;
+                    if G_TEST_MODE = 1 or G_TEST_MODE = 2 then
+                        stall_cycles := randint(-G_TEST_IPSTALL, G_TEST_IPSTALL);
+                        if stall_cycles > 0 then
+                            pdi_valid <= '0';
+                            wait for stall_cycles * clk_period;
+                            wait until rising_edge(clk);
+                        end if;
+                    end if;
+                    pdi_data <= word_block;
+                    pdi_valid <= '1';
+                    wait until rising_edge(clk) and pdi_ready = '1';
+               end loop;
             end if;
         end loop;
-
-        --! do operations in the falling edge of the io_clk
-        wait for io_clk_period/2;
-
-        while not endfile ( pdi_file ) loop
-            --! if the fifo is full, wait ...
-            fpdi_din_valid <= '1';
-            if ( fpdi_din_ready = '0' ) then
-                fpdi_din_valid <= '0';
-                wait until  fpdi_din_ready <= '1';
-                wait for    io_clk_period/2; --! write in the rising edge
-                fpdi_din_valid <= '1';
-            end if;
-
-            LWC_HREAD( line_data, word_block, read_result );
-            while (((read_result = False) or (valid_line = False))
-                and (not endfile( pdi_file )))
-            loop
-                readline(pdi_file, line_data);
-                read(line_data, temp_read, read_result);    --! read line header
-                if ( temp_read = cons_ins or temp_read = cons_hdr
-                    or temp_read = cons_dat)
-                then
-                    valid_line := True;
-                    fpdi_din_valid  <= '1';
-                else
-                    valid_line := False;
-                    fpdi_din_valid  <= '0';
-                end if;
-                LWC_HREAD( line_data, word_block, read_result ); --! read data
-            end loop;
-            fpdi_din <= word_block;
-               wait for io_clk_period;
-        end loop;
-        tv_count <= tv_count + 1;
-        fpdi_din_valid <= '0';
-        wait;
+        pdi_valid <= '0';
+        wait; -- forever
     end process;
+
     --! =======================================================================
     --! ==================== DATA POPULATION FOR SECRET DATA ==================
     tb_read_sdi : process
         variable line_data      : line;
-        variable word_block     : std_logic_vector(G_SWIDTH-1 downto 0)
-            := (others=>'0');
+        variable word_block     : std_logic_vector(SW-1 downto 0) := (others=>'0');
         variable read_result    : boolean;
-        variable loop_enable    : std_logic := '1';
-        variable temp_read      : string(1 to 6);
-        variable valid_line     : boolean := True;
+        variable line_head      : string(1 to 6);
+        variable stall_cycles    : integer;
     begin
-        --! Wait until reset is done
-        wait for 7*clk_period;
+        wait until reset_done;
+        wait until rising_edge(clk);
 
-        --! read header
-        while (not endfile (sdi_file)) and (loop_enable = '1') loop
-            if endfile (sdi_file) then
-                loop_enable := '0';
-            end if;
-
+        while not endfile(sdi_file) loop
             readline(sdi_file, line_data);
-            read(line_data, temp_read, read_result);
-            if (temp_read = cons_ins) then
-                loop_enable := '0';
+            read(line_data, line_head, read_result);
+            if read_result and (line_head = cons_ins or line_head = cons_hdr or line_head = cons_dat) then
+                loop
+                    LWC_HREAD(line_data, word_block, read_result);
+                    if not read_result then
+                        exit;
+                    end if;
+
+                    if G_TEST_MODE = 1 or G_TEST_MODE = 2 then
+                        stall_cycles := randint(-G_TEST_ISSTALL, G_TEST_ISSTALL);
+                        if stall_cycles > 0 then
+                            sdi_valid <= '0';
+                            wait for stall_cycles * clk_period;
+                            wait until rising_edge(clk);
+                        end if;
+                    end if;
+                    sdi_valid <= '1';
+                    sdi_data <= word_block;
+                    wait until rising_edge(clk) and sdi_ready = '1';
+               end loop;
             end if;
         end loop;
-
-        --! do operations in the falling edge of the io_clk
-        wait for io_clk_period/2;
-
-        while not endfile ( sdi_file ) loop
-            --! if the fifo is full, wait ...
-            fsdi_din_valid <= '1';
-            if ( fsdi_din_ready = '0' ) then
-                fsdi_din_valid <= '0';
-                wait until  fsdi_din_ready <= '1';
-                wait for    io_clk_period/2; --! write in the rising edge
-                fsdi_din_valid <= '1';
-            end if;
-
-            LWC_HREAD(line_data, word_block, read_result);
-            while (((read_result = False) or (valid_line = False))
-                and (not endfile(sdi_file)))
-            loop
-                readline(sdi_file, line_data);
-                read(line_data, temp_read, read_result);   --! read line header
-                if (temp_read = cons_ins or temp_read = cons_hdr
-                    or temp_read = cons_dat)
-                then
-                    valid_line := True;
-                    fsdi_din_valid  <= '1';
-                else
-                    valid_line := False;
-                    fsdi_din_valid  <= '0';
-                end if;
-                LWC_HREAD( line_data, word_block, read_result );    --! read data
-            end loop;
-            fsdi_din <= word_block;
-            wait for io_clk_period;
-        end loop;
-        fsdi_din_valid <= '0';
-        wait;
+        sdi_valid <= '0';
+        wait; -- forever
     end process;
-    --! =======================================================================
-
 
     --! =======================================================================
     --! =================== DATA VERIFICATION =================================
@@ -416,68 +301,104 @@ begin
         variable logMsg         : line;
         variable failMsg        : line;
         variable tb_block       : std_logic_vector(20      -1 downto 0);
-        variable word_block     : std_logic_vector(G_PWIDTH-1 downto 0) := (others=>'0');
+        variable word_block     : std_logic_vector(W-1 downto 0) := (others=>'0');
         variable read_result    : boolean;
         variable temp_read      : string(1 to 6);
-        variable valid_line     : boolean := True;
         variable word_count     : integer := 1;
-        variable word_pass      : integer := 1;
         variable instr_encoding : boolean := False;
         variable force_exit     : boolean := False;
         variable msgid          : integer;
---        variable keyid          : integer;
-        variable isEncrypt      : boolean := False;
+        variable keyid          : integer;
         variable opcode         : std_logic_vector(3 downto 0);
         variable num_fails      : integer := 0;
         variable testcase       : integer := 0;
+        variable stall_cycles   : integer;
     begin
-        wait for 6*clk_period;
+        wait until reset_done;
         if G_TEST_MODE = 4 then
             file_open(do_file, G_FNAME_DO, read_mode); -- reset the file pointer
         end if;
-        while (not endfile (do_file) and valid_line and (not force_exit)) loop
-            --! Keep reading new line until a valid line is found
-            LWC_HREAD( line_data, word_block, read_result );
-            while ((read_result = False or valid_line = False)
-                  and (not endfile(do_file)))
-            loop
-                readline(do_file, line_data);
-                line_no := line_no + 1;
-                read(line_data, temp_read, read_result); --! read line header
-                if (temp_read = cons_hdr
-                    or temp_read = cons_dat
-                    or temp_read = cons_stt)
-                then
-                    valid_line := True;
-                    word_count := 1;
-                else
-                    valid_line := False;
-                 --   report temp_read_bs;
-                    if (temp_read = cons_tb) then
-                        instr_encoding := True;
-                    end if;
-                end if;
+        wait until rising_edge(clk);
+        while not endfile(do_file) and not force_exit loop
+            readline(do_file, line_data);
+            line_no := line_no + 1;
+            read(line_data, temp_read, read_result);
+            if read_result then
+                if temp_read = cons_stt or temp_read = cons_hdr or temp_read = cons_dat then
+                    loop
+                        LWC_HREAD(line_data, word_block, read_result);
+                        if not read_result then
+                            exit;
+                        end if;
 
-                if (temp_read = cons_eof) then
+                        if G_TEST_MODE = 1 or G_TEST_MODE = 3 then
+                            stall_cycles := randint(-G_TEST_OSTALL, G_TEST_OSTALL);
+                            if stall_cycles > 0 then
+                                do_ready <= '0';
+                                wait for stall_cycles * clk_period;
+                                wait until rising_edge(clk);
+                            end if;
+                        end if;
+                        do_ready <= '1';
+                        wait until rising_edge(clk) and do_valid = '1';
+
+                        if not word_pass(do_data, word_block) then
+                            simulation_fails <= '1';
+                            write(logMsg, string'("[Log] Msg ID #")
+                                & integer'image(msgid)
+                                & string'(" fails at line #") & integer'image(line_no)
+                                & string'(" word #") & integer'image(word_count));
+                            writeline(log_file,logMsg);
+                            write(logMsg, string'("[Log]     Expected: ")
+                                & LWC_TO_HSTRING(word_block)
+                                & string'(" Received: ") & LWC_TO_HSTRING(do_data));
+                            writeline(log_file,logMsg);
+
+                            report " --- MsgID #" & integer'image(testcase)
+                                & " Data line #" & integer'image(line_no)
+                                & " Word #" & integer'image(word_count)
+                                & " at " & time'image(now) & " FAILS ---"
+                                severity error;
+                            report "Expected: " & LWC_TO_HSTRING(word_block)
+                                & " Actual: " & LWC_TO_HSTRING(do_data) severity error;
+                            write(result_file, string'("fail"));
+                            num_fails := num_fails + 1;
+                            write(failMsg,  string'("Failure #") & integer'image(num_fails)
+                                & " MsgID: " & integer'image(testcase));-- & " Operation: ");
+
+                            write(failMsg, string'(" Line: ") & integer'image(line_no)
+                                & " Word: " & integer'image(word_count)
+                                & " Expected: " & LWC_TO_HSTRING(word_block)
+                                & " Received: " & LWC_TO_HSTRING(do_data));
+                            writeline(failures_file, failMsg);
+                            if num_fails >= G_MAX_FAILURES then
+                                force_exit := True;
+                            end if;
+                        else
+                            write(logMsg, string'("[Log]     Expected: ")
+                                & LWC_TO_HSTRING(word_block)
+                                & string'(" Received: ") & LWC_TO_HSTRING(do_data)
+                                & string'(" Matched!"));
+                            writeline(log_file,logMsg);
+                        end if;
+                        word_count := word_count + 1;
+                end loop;
+                elsif temp_read = cons_eof then
                     force_exit := True;
-                end if;
-
-                if (instr_encoding) then
-                	testcase := testcase + 1;
+                elsif temp_read = cons_tb then
+                    testcase := testcase + 1;
                     LWC_HREAD(line_data, tb_block, read_result); --! read data
                     instr_encoding := False;
                     read_result    := False;
                     opcode := tb_block(19 downto 16);
---                    keyid  := to_integer(to_01(unsigned(tb_block(15 downto 8))));
+                    keyid  := to_integer(to_01(unsigned(tb_block(15 downto 8))));
                     msgid  := to_integer(to_01(unsigned(tb_block(7  downto 0))));
-                    isEncrypt := False;
                     if ((opcode = INST_DEC or opcode = INST_ENC or opcode = INST_HASH)
                         or (opcode = INST_SUCCESS or opcode = INST_FAILURE))
                     then
                         write(logMsg, string'("[Log] == Verifying msg ID #")
                             & integer'image(testcase));
                         if (opcode = INST_ENC) then
-                            isEncrypt := True;
                             write(logMsg, string'(" for ENC"));
                         elsif (opcode = INST_HASH) then
                             write(logMsg, string'(" for HASH"));
@@ -486,121 +407,37 @@ begin
                         end if;
                         writeline(log_file,logMsg);
                     end if;
-
-                    report "---------Started verifying MsgID = "
-                        & integer'image(testcase) & " at "
-                        & time'image(now) severity note;
-                else
-                    LWC_HREAD(line_data, word_block, read_result); --! read data
+                    report "---------Started verifying MsgID = " & integer'image(testcase) severity note;
                 end if;
-            end loop;
-
-            --! if the core is slow in outputting the digested message, wait ...
-            if ( valid_line ) then
-                fdo_dout_ready <= '1';
-                if ( fdo_dout_valid = '0') then
-                    fdo_dout_ready <= '0';
-                    wait until fdo_dout_valid = '1';
-                    wait for io_clk_period/2;
-                    fdo_dout_ready <= '1';
-                end if;
-
-                word_pass := 1;
-                for i in G_PWIDTH-1 downto 0 loop
-                    if  fdo_dout(i) /= word_block(i)
-                        and word_block(i) /= 'X'
-                    then
-                        word_pass := 0;
-                    end if;
-                end loop;
-                if word_pass = 0 then
-                    simulation_fails <= '1';
-                    write(logMsg, string'("[Log] Msg ID #")
-                        & integer'image(msgid)
-                        & string'(" fails at line #") & integer'image(line_no)
-                        & string'(" word #") & integer'image(word_count));
-                    writeline(log_file,logMsg);
-                    write(logMsg, string'("[Log]     Expected: ")
-                        & LWC_TO_HSTRING(word_block)
-                        & string'(" Received: ") & LWC_TO_HSTRING(fdo_dout));
-                    writeline(log_file,logMsg);
-
-                    report " --- MsgID #" & integer'image(testcase)
-                        & " Data line #" & integer'image(line_no)
-                        & " Word #" & integer'image(word_count)
-                        & " at " & time'image(now) & " FAILS ---"
-                        severity error;
-                    report "Expected: " & LWC_TO_HSTRING(word_block)
-                        & " Actual: " & LWC_TO_HSTRING(fdo_dout) severity error;
-                    write(result_file, string'("fail"));
-                    num_fails := num_fails + 1;
-                    write(failMsg,  string'("Failure #") & integer'image(num_fails)
-                    	& " MsgID: " & integer'image(testcase));-- & " Operation: ");
---                    if (opcode = INST_ENC) then
---                        write(failMsg, string'("ENC"));
---                    elsif(opcode = INST_HASH) then
---                        write(failMsg, string'("HASH"));
---                    else
---                        write(failMsg, string'("DEC"));
---                    end if;
-                    write(failMsg, string'(" Line: ") & integer'image(line_no)
-                    	& " Word: " & integer'image(word_count)
-                    	& " Expected: " & LWC_TO_HSTRING(word_block)
-                        & " Received: " & LWC_TO_HSTRING(fdo_dout));
-                    writeline(failures_file, failMsg);
-                    if num_fails >= G_MAX_FAILURES then
-                        force_exit := True;
-                    else
-                        if isEncrypt = False then
-                            report "---------Skip to the next instruction"
-                                & " at " & time'image(now) severity error;
-                            write(logMsg,
-                                string'("[Log]  ...skips to next message ID"));
-                            writeline(log_file, logMsg);
-                        end if;
-                    end if;
-                else
-                    write(logMsg, string'("[Log]     Expected: ")
-                        & LWC_TO_HSTRING(word_block)
-                        & string'(" Received: ") & LWC_TO_HSTRING(fdo_dout)
-                        & string'(" Matched!"));
-                    writeline(log_file,logMsg);
-                end if;
-
-                wait for io_clk_period;
-                word_count := word_count + 1;
             end if;
         end loop;
-
-        fdo_dout_ready <= '0';
-        wait for io_clk_period;
+        file_close(do_file);
+        do_ready <= '0';
+        wait until rising_edge(clk);
 
         if (simulation_fails = '1') then
-            report "FAIL (1): SIMULATION FINISHED || Input/Output files :: T_T"
-                & G_FNAME_PDI & "/" & G_FNAME_SDI
-                & "/" & G_FNAME_DO severity error;
+            report "FAIL (1): SIMULATION FINISHED at " & time'image(now) severity error;
+            write(logMsg, "FAIL (1): SIMULATION FINISHED at " & time'image(now));
+            writeline(log_file,logMsg);
             write(result_file, "1");
         else
-            report "PASS (0): SIMULATION FINISHED || Input/Output files :: ^0^"
-                & G_FNAME_PDI & "/" & G_FNAME_SDI
-                & "/" & G_FNAME_DO severity error;
+            report "PASS (0): SIMULATION FINISHED at " & time'image(now) severity note;
             write(result_file, "0");
         end if;
+
         write(logMsg, string'("[Log] Done"));
         writeline(log_file,logMsg);
+        file_close(result_file);
+        file_close(log_file);
         stop_clock <= True;
-        file_close(do_file);
         wait;
     end process;
-    --! =======================================================================
-
 
     --! =======================================================================
-    --! =================== Test MODE =========================================
     --Simple process to count cycles
     clock_conter: process
     begin
-        wait until rising_edge(io_clk);
+        wait until rising_edge(clk);
         clk_cycle_counter <= clk_cycle_counter + 1;
     end process;
     
@@ -610,20 +447,12 @@ begin
         wait until start_latency_timer = '1';
         latency_done <= '0';
         latency <= 0;
-        if pdi_ready /= '1' then -- Wait until first word is read before starting timer
-            wait until pdi_ready = '1';
-        end if;
+        wait until rising_edge(clk) and pdi_valid = '1' and pdi_ready = '1';
         latency_start := clk_cycle_counter;
-        wait until rising_edge(clk);
-        if do_valid /= '1' then
-         --   wait on do;
-            wait until do_valid = '1'; -- wait until first word of output
-            wait until falling_edge(clk);
-        end if;
-        latency <= (clk_cycle_counter - latency_start) + 1; -- Add 1 for Fifo write
+        wait until rising_edge(clk) and do_valid = '1' and do_ready = '1';
+        latency <= clk_cycle_counter - latency_start;
         latency_done <= '1';
     end process;
-        
 
     genMeasurementMode : process
         variable seg_cnt, seg_cnt_start : integer := 0;
@@ -646,7 +475,7 @@ begin
         variable block_size_ad : integer := -1;
         variable block_size_hash : integer := -1;
         variable ina, inm, inc, inh : integer := 0;
-        variable charindex : integer :=  15; --std_logic_vector(G_PWIDTH - 1 downto 0);
+        variable charindex : integer := 15; --std_logic_vector(W - 1 downto 0);
     begin
         if G_TEST_MODE = 4 then
             stall_msg <= '0';
@@ -693,37 +522,37 @@ begin
             exec_time := 0;
             seg_cnt := 0;
             -- Determine Instruction
-            ins_opcode := pdi_delayed(G_PWIDTH-1 downto G_PWIDTH-4);
+            ins_opcode := pdi_data(W-1 downto W-4);
             if ins_opcode = INST_ENC or ins_opcode = INST_DEC or ins_opcode = INST_HASH or ins_opcode = INST_ACTKEY then
               msg_start_time := clk_cycle_counter;
               start_time := time(now);
                 if ins_opcode = INST_ACTKEY then
                     new_key := 1;
                     wait until rising_edge(clk) and pdi_ready = '1' and pdi_valid = '1';
-                    ins_opcode := pdi_delayed(G_PWIDTH-1 downto G_PWIDTH-4);
+                    ins_opcode := pdi_data(W-1 downto W-4);
                 end if;
             end if;
-                ----- Segment loop-------------
-            segment_loop : while True loop
-                wait until falling_edge(clk) and pdi_ready = '1' and pdi_valid = '1';
+            ----- Segment loop-------------
+            segment_loop: while True loop
+                wait until rising_edge(clk) and pdi_ready = '1' and pdi_valid = '1';
                 -- Obtain segment header
                 if seg_cnt = 0 then
                     -- parse segment header
-                    seg_type := pdi_delayed(G_PWIDTH-1 downto G_PWIDTH-4);
-                    seg_eoi := pdi_delayed(G_PWIDTH-6);
-                    seg_eot := pdi_delayed(G_PWIDTH-7);
-                    seg_last := pdi_delayed(G_PWIDTH-8);
-                    if G_PWIDTH = 8 then
-                       wait until falling_edge(clk) and pdi_ready = '1' and pdi_valid = '1'; -- @suppress "Dead code"
-                       wait until falling_edge(clk) and pdi_ready = '1' and pdi_valid = '1'; --wait segment length top
-                       seg_cnt := to_integer(unsigned(pdi_delayed & "00000000"));
-                       wait until falling_edge(clk) and pdi_ready = '1' and pdi_valid = '1';
-                       seg_cnt := seg_cnt + to_integer(unsigned(pdi_delayed));
-                    elsif G_PWIDTH = 16 then -- @suppress "Dead code"
-                       wait until falling_edge(clk) and pdi_ready = '1' and pdi_valid = '1'; --wait segment length top
-                       seg_cnt := to_integer(unsigned(pdi_delayed));
-                    else --G_PWIDTH 32
-                        seg_cnt := to_integer(unsigned(pdi_delayed(15 downto 0)));
+                    seg_type := pdi_data(W-1 downto W-4);
+                    seg_eoi := pdi_data(W-6);
+                    seg_eot := pdi_data(W-7);
+                    seg_last := pdi_data(W-8);
+                    if W = 8 then
+                       wait until rising_edge(clk) and pdi_ready = '1' and pdi_valid = '1'; -- @suppress "Dead code"
+                       wait until rising_edge(clk) and pdi_ready = '1' and pdi_valid = '1'; --wait segment length top
+                       seg_cnt := to_integer(unsigned(pdi_data & "00000000"));
+                       wait until rising_edge(clk) and pdi_ready = '1' and pdi_valid = '1';
+                       seg_cnt := seg_cnt + to_integer(unsigned(pdi_data));
+                    elsif W = 16 then -- @suppress "Dead code"
+                       wait until rising_edge(clk) and pdi_ready = '1' and pdi_valid = '1'; --wait segment length top
+                       seg_cnt := to_integer(unsigned(pdi_data));
+                    else --W 32
+                        seg_cnt := to_integer(unsigned(pdi_data(15 downto 0)));
                     end if;
                     seg_cnt_start := seg_cnt;
                     if seg_type = HDR_PT then pt_size := pt_size + seg_cnt;
@@ -735,10 +564,10 @@ begin
                     if seg_cnt = 0 and seg_last = '1' and
                                 (seg_type = HDR_PT or seg_type = HDR_TAG or seg_type = HDR_HASH_MSG) then
 
-                        wait until falling_edge(clk);
+                        wait until rising_edge(clk);
                         stall_msg <= '1'; -- last segment  wait until cipher is done
-                        if (do_last /= '1' or (do /= SUCCESS_WORD and do /= FAILURE_WORD)) then
-                                wait until (do_last = '1' and (do = SUCCESS_WORD or do = FAILURE_WORD));
+                        if (do_last /= '1' or (do_data /= SUCCESS_WORD and do_data /= FAILURE_WORD)) then
+                                wait until (do_last = '1' and (do_data = SUCCESS_WORD or do_data = FAILURE_WORD));
                         end if;
                         stall_msg <= '0';
                         exec_time := clk_cycle_counter-msg_start_time;
@@ -749,14 +578,14 @@ begin
                     if (seg_cnt = seg_cnt_start) and (seg_type = HDR_PT or seg_type = HDR_CT) then 
                         start_latency_timer <= '1';
                     end if;
-                    if (seg_cnt <= 4 and G_PWIDTH = 32) or (seg_cnt <= 2 and G_PWIDTH = 16) or (seg_cnt <= 1 and G_PWIDTH = 8) then
+                    if (seg_cnt <= 4 and W = 32) or (seg_cnt <= 2 and W = 16) or (seg_cnt <= 1 and W = 8) then
                         seg_cnt := 0;
                         if ((seg_type = HDR_PT or seg_type = HDR_TAG or seg_type = HDR_HASH_MSG) and seg_last = '1')then
-                            wait until falling_edge(clk);
+                            wait until rising_edge(clk);
                             stall_msg <= '1'; -- last segment wait until cipher is done
                             if latency_done /= '1' and start_latency_timer = '1' then
                                 wait until latency_done = '1';
-                                if (do_last = '1' and (do = SUCCESS_WORD or do = FAILURE_WORD)) then
+                                if (do_last = '1' and (do_data = SUCCESS_WORD or do_data = FAILURE_WORD)) then
                                     stall_msg <= '0';
                                     exec_time := clk_cycle_counter-msg_start_time;
                                     msg_idx := msg_idx + 1;
@@ -764,16 +593,16 @@ begin
                                 end if;
                             end if;
                             start_latency_timer <= '0';
-                            if (do_last /= '1' or (do /= SUCCESS_WORD and do /= FAILURE_WORD)) then
-                                wait until (do_last = '1' and (do = SUCCESS_WORD or do = FAILURE_WORD));
+                            if (do_last /= '1' or (do_data /= SUCCESS_WORD and do_data /= FAILURE_WORD)) then
+                                wait until (do_last = '1' and (do_data = SUCCESS_WORD or do_data = FAILURE_WORD));
                             end if;
                             stall_msg <= '0';
-                            exec_time := clk_cycle_counter-msg_start_time;
+                            exec_time := clk_cycle_counter - msg_start_time;
                             msg_idx := msg_idx + 1;
                             exit;
                         end if;
                     else
-                        seg_cnt := seg_cnt - (G_PWIDTH / 8);
+                        seg_cnt := seg_cnt - (W / 8);
                     end if;
                 end if;
             end loop segment_loop;
@@ -802,9 +631,9 @@ begin
                 report "Authenticated Encryption";
                 report "AD size = " & integer'image(ad_size) & " bytes, PT size = " & integer'image(pt_size) & " bytes";
                 report "Na = " & integer'image((ad_size/block_size_ad)) & " Bla = " & 
-		                		integer'image(ad_size mod block_size_ad) & " Ina = " & integer'image(ina);
+                                integer'image(ad_size mod block_size_ad) & " Ina = " & integer'image(ina);
                 report "Nm = " & integer'image((pt_size/block_size)) & " Blm = " &
-		                		integer'image(pt_size mod block_size) & " Inm = " & integer'image(inm);
+                                integer'image(pt_size mod block_size) & " Inm = " & integer'image(inm);
                 report "Execution time = " & integer'image(exec_time) & " cycles";
                 report "Latency = " & integer'image(latency) & " cycles";
                 
@@ -867,11 +696,11 @@ begin
                 end if;
                 report "Authenticated Decryption";
                 report "AD size = " & integer'image(ad_size) & " bytes, CT size = " & 
-                				integer'image(ct_size) & " bytes";
+                                integer'image(ct_size) & " bytes";
                 report "Na = " & integer'image((ad_size/block_size_ad)) & " Bla = " & 
-                				integer'image(ad_size mod block_size_ad) & " Ina = " & integer'image(ina);
+                                integer'image(ad_size mod block_size_ad) & " Ina = " & integer'image(ina);
                 report "Nc = " & integer'image((ct_size/block_size)) & " Blm = " & 
-                				integer'image(ct_size mod block_size) & " Inc = " & integer'image(inc);
+                                integer'image(ct_size mod block_size) & " Inc = " & integer'image(inc);
                 report "Execution time = " & integer'image(exec_time) & " cycles";
                 report "Latency = " & integer'image(latency) & " cycles";
                 write(timingMsg, string'("Authenticated Decryption"));
@@ -932,7 +761,7 @@ begin
                 report "Hashing";
                 report "Hash msg size = " & integer'image(hash_size) & " bytes";
                 report "Nh = " & integer'image((hash_size/block_size_hash)) & " Blh = " &
-                				integer'image(hash_size mod block_size_hash) & " Inc = " & integer'image(inh);
+                                integer'image(hash_size mod block_size_hash) & " Inc = " & integer'image(inh);
                 report "Execution time = " & integer'image(exec_time) & " cycles";
                 
                 write(timingMsg, string'("Hashing"));
@@ -967,69 +796,8 @@ begin
                                 integer'image(latency));
                 writeline(timing_csv, timingMsg);
             end if;
-         else
-             wait;
-         end if;
-    end process;
-
-
-    genInputStall1 : process
-    begin
-        if G_TEST_MODE = 1 or G_TEST_MODE = 2 then
-            wait until rising_edge(io_clk);
-            wait for 1/4*io_clk_period;
-            if (pdi_ready = '0') then
-                wait until falling_edge(io_clk) and pdi_ready = '1';
-            end if;
-            if (pdi_valid = '0') then
-                wait until falling_edge(io_clk) and pdi_valid = '1';
-            end if;
-            wait for io_clk_period;
-            stall_pdi_valid <= '1';
-            wait for io_clk_period*G_TEST_IPSTALL;
-            stall_pdi_valid <= '0';
         else
             wait;
         end if;
     end process;
-
-    genInputStall2 : process
-    begin
-        if G_TEST_MODE = 1 or G_TEST_MODE = 2 then
-            wait until rising_edge(io_clk);
-            wait for 1/4*io_clk_period;
-            if (sdi_ready = '0') then
-                wait until falling_edge(io_clk) and sdi_ready = '1';
-            end if;
-            if (sdi_valid = '0') then
-                wait until falling_edge(io_clk) and sdi_valid = '1';
-            end if;
-            wait for io_clk_period;
-            stall_sdi_valid <= '1';
-            wait for io_clk_period*G_TEST_ISSTALL;
-            stall_sdi_valid <= '0';
-        else
-            wait;
-        end if;
-    end process;
-
-    genOutputStall : process
-    begin
-        if G_TEST_MODE = 1 or G_TEST_MODE = 3 then
-            wait until rising_edge(io_clk);
-            wait for 1/4*io_clk_period;
-            if (do_ready = '0') then
-                wait until falling_edge(io_clk) and do_ready = '1';
-            end if;
-            if (do_valid = '0') then
-                wait until falling_edge(io_clk) and do_valid = '1';
-            end if;
-            wait for io_clk_period;
-            stall_do_full <= '1';
-            wait for io_clk_period*G_TEST_OSTALL;
-            stall_do_full <= '0';
-        else
-            wait;
-        end if;
-    end process;
-end;
+end architecture;

--- a/hardware/LWC_tb/LWC_TB.vhd
+++ b/hardware/LWC_tb/LWC_TB.vhd
@@ -276,9 +276,9 @@ begin
                         pdi_valid <= '1';
                     end if;
 
-                    first_inst := line_head = cons_ins and (word_block(W-1 downto W-8) = X"70" or word_block(W-1 downto W-8) = X"80");
+                    first_inst := line_head = cons_ins and ((word_block(W-1 downto W-8) = X"70") or (word_block(W-1 downto W-8) = X"80"));
 
-                    if G_TEST_MODE = 4 and first_inst   and not timingBoard.isEmpty then
+                    if G_TEST_MODE = 4 and first_inst and not timingBoard.isEmpty then
                         pdi_valid <= '0';
                         while not timingBoard.isEmpty loop
                             wait until rising_edge(clk);

--- a/hardware/LWC_tb/LWC_TB_2pass_conf.vhd
+++ b/hardware/LWC_tb/LWC_TB_2pass_conf.vhd
@@ -1,0 +1,7 @@
+configuration LWC_TB_2pass_conf of LWC_TB is
+    for TB
+        for uut : LWC
+            use entity work.LWC_TB_2pass_uut; -- either RTL or Verilog netlist
+        end for;
+    end for;
+end configuration;

--- a/hardware/LWC_tb/LWC_TB_2pass_uut.vhd
+++ b/hardware/LWC_tb/LWC_TB_2pass_uut.vhd
@@ -1,0 +1,100 @@
+library ieee;
+use ieee.std_logic_1164.all;
+
+use work.NIST_LWAPI_pkg.all;
+use work.LWC_TB_pkg.all;
+
+entity LWC_TB_2pass_uut is
+    generic (
+          G_MAX_SEGMENT_BYTES : integer := 16 * 1024
+    );
+    port (
+        clk             : in  std_logic;
+        rst             : in  std_logic;
+        pdi_data        : in  std_logic_vector(W-1 downto 0);
+        pdi_valid       : in  std_logic;
+        pdi_ready       : out std_logic;
+        sdi_data        : in  std_logic_vector(SW-1 downto 0);
+        sdi_valid       : in  std_logic;
+        sdi_ready       : out std_logic;
+        do_data         : out std_logic_vector(W-1 downto 0);
+        do_ready        : in  std_logic;
+        do_valid        : out std_logic;
+        do_last         : out std_logic
+    );
+end entity;
+
+architecture structural of LWC_TB_2pass_uut is
+
+    --! fdi/o
+    signal fdi_data             : std_logic_vector(W-1 downto 0);
+    signal fdo_data             : std_logic_vector(W-1 downto 0);
+    signal fdi_valid            : std_logic;
+    signal fdo_valid            : std_logic;
+    signal fdi_ready            : std_logic;
+    signal fdo_ready            : std_logic;
+
+    component LWC_2pass
+        port (
+            clk       : in  std_logic;
+            rst       : in  std_logic;
+            pdi_data  : in  std_logic_vector(W - 1 downto 0);
+            pdi_valid : in  std_logic;
+            pdi_ready : out std_logic;
+            sdi_data  : in  std_logic_vector(SW - 1 downto 0);
+            sdi_valid : in  std_logic;
+            sdi_ready : out std_logic;
+            do_data   : out std_logic_vector(W - 1 downto 0);
+            do_ready  : in  std_logic;
+            do_valid  : out std_logic;
+            do_last   : out std_logic;
+            fdi_data  : in  std_logic_vector(W - 1 downto 0);
+            fdi_valid : in  std_logic;
+            fdi_ready : out std_logic;
+            fdo_data  : out std_logic_vector(W - 1 downto 0);
+            fdo_valid : out std_logic;
+            fdo_ready : in  std_logic
+        );
+    end component;
+begin
+
+    assert False report "Using LWC_2pass with G_MAX_SEGMENT_BYTES=" & integer'image(G_MAX_SEGMENT_BYTES) severity warning;
+    
+    uut: LWC_2pass
+        port map(
+            clk          => clk,
+            rst          => rst,
+            pdi_data     => pdi_data,
+            pdi_valid    => pdi_valid,
+            pdi_ready    => pdi_ready,
+            sdi_data     => sdi_data,
+            sdi_valid    => sdi_valid,
+            sdi_ready    => sdi_ready,
+            do_data      => do_data,
+            do_ready     => do_ready,
+            do_valid     => do_valid,
+            do_last      => do_last,
+            fdi_data     => fdi_data,
+            fdi_valid    => fdi_valid,
+            fdi_ready    => fdi_ready,
+            fdo_data     => fdo_data,
+            fdo_valid    => fdo_valid,
+            fdo_ready    => fdo_ready
+        );
+
+    twoPassfifo : entity work.fwft_fifo_tb
+        generic map(
+            G_W              => W,
+            G_LOG2DEPTH      => log2_ceil(8 * G_MAX_SEGMENT_BYTES / W)
+        )
+        port map(
+            clk              => clk,
+            rst              => rst,
+            din              => fdo_data,
+            din_valid        => fdo_valid,
+            din_ready        => fdo_ready,
+            dout             => fdi_data,
+            dout_valid       => fdi_valid,
+            dout_ready       => fdi_ready
+        );  
+end architecture;

--- a/hardware/LWC_tb/LWC_TB_2pass_wrapper_conf.vhd
+++ b/hardware/LWC_tb/LWC_TB_2pass_wrapper_conf.vhd
@@ -1,0 +1,7 @@
+configuration LWC_TB_2pass_wrapper_conf of LWC_TB is
+    for TB
+        for uut : LWC
+            use entity work.LWC_TB_2pass_wrapper_uut; -- either RTL or Verilog netlist
+        end for;
+    end for;
+end configuration;

--- a/hardware/LWC_tb/LWC_TB_2pass_wrapper_uut.vhd
+++ b/hardware/LWC_tb/LWC_TB_2pass_wrapper_uut.vhd
@@ -1,0 +1,101 @@
+library ieee;
+use ieee.std_logic_1164.all;
+
+use work.NIST_LWAPI_pkg.all;
+use work.LWC_TB_pkg.all;
+
+entity LWC_TB_2pass_wrapper_uut is
+    generic (
+        MAX_SEGMENT_BYTES: integer := 16 * 1024
+    );
+    port (
+        clk             : in  std_logic;
+        rst             : in  std_logic;
+        pdi_data        : in  std_logic_vector(W-1 downto 0);
+        pdi_valid       : in  std_logic;
+        pdi_ready       : out std_logic;
+        sdi_data        : in  std_logic_vector(SW-1 downto 0);
+        sdi_valid       : in  std_logic;
+        sdi_ready       : out std_logic;
+        do_data         : out std_logic_vector(W-1 downto 0);
+        do_ready        : in  std_logic;
+        do_valid        : out std_logic;
+        do_last         : out std_logic
+    );
+end entity;
+
+architecture structural of LWC_TB_2pass_wrapper_uut is
+
+    --! fdi/o
+    signal fdi_data             : std_logic_vector(W-1 downto 0);
+    signal fdo_data             : std_logic_vector(W-1 downto 0);
+    signal fdi_valid            : std_logic;
+    signal fdo_valid            : std_logic;
+    signal fdi_ready            : std_logic;
+    signal fdo_ready            : std_logic;
+
+    component LWC_2pass_wrapper
+        port (
+            clk       : in  std_logic;
+            rst       : in  std_logic;
+            pdi_data  : in  std_logic_vector(W - 1 downto 0);
+            pdi_valid : in  std_logic;
+            pdi_ready : out std_logic;
+            sdi_data  : in  std_logic_vector(SW - 1 downto 0);
+            sdi_valid : in  std_logic;
+            sdi_ready : out std_logic;
+            do_data   : out std_logic_vector(W - 1 downto 0);
+            do_ready  : in  std_logic;
+            do_valid  : out std_logic;
+            do_last   : out std_logic;
+            fdi_data  : in  std_logic_vector(W - 1 downto 0);
+            fdi_valid : in  std_logic;
+            fdi_ready : out std_logic;
+            fdo_data  : out std_logic_vector(W - 1 downto 0);
+            fdo_valid : out std_logic;
+            fdo_ready : in  std_logic
+        );
+    end component;
+begin
+
+    assert False report "Using LWC_2pass+wrapper with G_MAX_SEGMENT_BYTES=" & integer'image(G_MAX_SEGMENT_BYTES) severity warning;
+    
+    uut: LWC_2pass_wrapper
+        port map(
+            clk          => clk,
+            rst          => rst,
+            pdi_data     => pdi_data,
+            pdi_valid    => pdi_valid,
+            pdi_ready    => pdi_ready,
+            sdi_data     => sdi_data,
+            sdi_valid    => sdi_valid,
+            sdi_ready    => sdi_ready,
+            do_data      => do_data,
+            do_ready     => do_ready,
+            do_valid     => do_valid,
+            do_last      => do_last,
+            fdi_data     => fdi_data,
+            fdi_valid    => fdi_valid,
+            fdi_ready    => fdi_ready,
+            fdo_data     => fdo_data,
+            fdo_valid    => fdo_valid,
+            fdo_ready    => fdo_ready
+        );
+
+    twoPassfifo : entity work.fwft_fifo_tb
+        generic map(
+            G_W              => W,
+            G_LOG2DEPTH      => log2_ceil(8*MAX_SEGMENT_BYTES/W)
+        )
+        port map(
+            clk              => clk,
+            rst              => rst,
+            din              => fdo_data,
+            din_valid        => fdo_valid,
+            din_ready        => fdo_ready,
+            dout             => fdi_data,
+            dout_valid       => fdi_valid,
+            dout_ready       => fdi_ready
+        );  
+
+end architecture;

--- a/hardware/LWC_tb/LWC_TB_2pass_wrapper_uut.vhd
+++ b/hardware/LWC_tb/LWC_TB_2pass_wrapper_uut.vhd
@@ -6,7 +6,7 @@ use work.LWC_TB_pkg.all;
 
 entity LWC_TB_2pass_wrapper_uut is
     generic (
-        MAX_SEGMENT_BYTES: integer := 16 * 1024
+        G_MAX_SEGMENT_BYTES: integer := 16 * 1024
     );
     port (
         clk             : in  std_logic;
@@ -85,7 +85,7 @@ begin
     twoPassfifo : entity work.fwft_fifo_tb
         generic map(
             G_W              => W,
-            G_LOG2DEPTH      => log2_ceil(8*MAX_SEGMENT_BYTES/W)
+            G_LOG2DEPTH      => log2_ceil(8*G_MAX_SEGMENT_BYTES/W)
         )
         port map(
             clk              => clk,

--- a/hardware/LWC_tb/LWC_TB_pkg.vhd
+++ b/hardware/LWC_tb/LWC_TB_pkg.vhd
@@ -4,7 +4,7 @@
 --! @project    LWC Hardware API Testbench
 --!                  
 --! @copyright  
---! @version    1.1.1
+--! @version    1.1.2
 --! @license    
 -------------------------------------------------------------------------------
 
@@ -19,20 +19,6 @@ package LWC_TB_pkg is
     procedure LWC_HREAD (L : inout LINE; VALUE : out STD_LOGIC_VECTOR; GOOD : out BOOLEAN);
     
     function log2_ceil (N : NATURAL) RETURN NATURAL;
-
-    type RandGen is protected
-        procedure seed(s : in POSITIVE);
-        procedure seed(s1, s2 : in POSITIVE);
-        impure function randint(min, max : INTEGER) return INTEGER;
-    end protected;
-
-    type LinkedList is protected
-        procedure push(constant d   : in NATURAL);
-        impure function pop return NATURAL;
-        impure function last return NATURAL;
-        impure function isEmpty return BOOLEAN;
-    end protected;
-
 end package LWC_TB_pkg;
 
 package body LWC_TB_pkg is
@@ -192,41 +178,6 @@ package body LWC_TB_pkg is
     end if;
     end function LWC_to_hstring;
 
-    
-    type RandGen is protected body
-
-        variable seed1 : positive;
-        variable seed2 : positive;
-  
-        procedure seed(s : in positive) is
-        begin
-            seed1 := s;
-            if s > 1 then
-                seed2 := s - 1;
-            else
-                seed2 := s + 42;
-            end if;
-        end procedure;
-
-        procedure seed(s1, s2 : in positive) is
-        begin
-            seed1 := s1;
-            seed2 := s2;
-        end procedure;
-
-        impure function random return real is
-            variable result : real;
-        begin
-            uniform(seed1, seed2, result);
-            return result;
-        end function;
-
-        impure function randint(min, max : integer) return integer is
-        begin
-            return integer(trunc(real(max - min + 1) * random)) + min;
-        end function;
-    end protected body;
-
     function log2_ceil (n : natural) return natural is
     begin
         if (n = 0) then
@@ -241,57 +192,4 @@ package body LWC_TB_pkg is
             end if;
         end if;
     end function log2_ceil;
-
-    type LinkedList is protected body
-        type Item;
-        type ItemPtr is access Item;
-        type Item is record
-            d   : NATURAL;
-            nxt : ItemPtr;
-        end record;
- 
-        variable root : ItemPtr;
- 
-        procedure push(constant d   : in NATURAL) is
-            variable newNode : ItemPtr;
-            variable node    : ItemPtr;
-        begin
-            newNode   := new Item;
-            newNode.d := d;
-            if root = null then
-                root := newNode;
-            else
-                node := root;
-                while node.nxt /= null loop
-                   node := node.nxt;
-                end loop;
-                node.nxt := newNode;
-            end if;
-        end;
- 
-        impure function pop return NATURAL is
-            variable node : ItemPtr;
-            variable ret : NATURAL;
-        begin
-            node := root;
-            root := root.nxt;
-            ret  := node.d;
-            deallocate(node);
-            return ret;
-        end;
-
-
-        impure function last return NATURAL is
-        begin
-            return root.d;
-        end;
- 
-        impure function isEmpty return BOOLEAN is
-        begin
-            return root = null;
-        end;
-
- 
-    end protected body;
-
 end package body LWC_TB_pkg;

--- a/hardware/LWC_tb/LWC_TB_pkg.vhd
+++ b/hardware/LWC_tb/LWC_TB_pkg.vhd
@@ -1,29 +1,30 @@
 -------------------------------------------------------------------------------
---! @file       LWC_TB_compatibility_pkg.vhd
---! @brief      Minimalistic std_logic_1164 compatibility package for LWC_TB
---!             Provides implementations for TO_HSTRING TO_HSTRING which are only
---!                 standardized since on VHDL 2008, while avoiding namespace clashes.
+--! @file       LWC_TB_pkg.vhd
+--! @brief      Testbench Utility Package
 --! @project    LWC Hardware API Testbench
---! @author     David Bishop <dbishop@vhdl.org> <dbishopx@gmail.com>
---!                  adopted by: Kamyar Mohajerani <kamyar@ieee.org>
+--!                  
 --! @copyright  
 --! @version    1.0
 --! @license    
---! @note       Based on 'std_logic_1164_additions.vhd'
---!                 retrieved from https://github.com/FPHDL/fphdl
 -------------------------------------------------------------------------------
 
 library ieee;
 use ieee.std_logic_1164.all;
+use ieee.math_real.all;
+
 use std.textio.all;
 
-package LWC_TB_compatibility_pkg is
+package LWC_TB_pkg is
   function LWC_TO_HSTRING (VALUE : STD_LOGIC_VECTOR) return STRING;
   procedure LWC_HREAD (L : inout LINE; VALUE : out STD_LOGIC_VECTOR; GOOD : out BOOLEAN);
-end package LWC_TB_compatibility_pkg;
- 
-package body LWC_TB_compatibility_pkg is
- 
+  procedure seed(s : in positive);
+  procedure seed(s1, s2 : in positive);
+  impure function randint(min, max : integer) return integer;
+  function log2_ceil (N : NATURAL) RETURN NATURAL;
+end package LWC_TB_pkg;
+
+package body LWC_TB_pkg is
+
   function or_reduce (l : STD_LOGIC_VECTOR) return STD_LOGIC is
     variable result : STD_LOGIC := '0';
   begin
@@ -35,7 +36,7 @@ package body LWC_TB_compatibility_pkg is
 
   constant NBSP : CHARACTER      := CHARACTER'val(160); -- space character
   constant NUS  : STRING(2 to 1) := (others => ' '); -- null STRING -- @suppress "Null range: The left argument is strictly larger than the right"
- 
+
   procedure skip_whitespace (
     L : inout LINE) is
     variable c : CHARACTER;
@@ -53,9 +54,9 @@ package body LWC_TB_compatibility_pkg is
   end procedure skip_whitespace;
 
   procedure Char2QuadBits (C           :     CHARACTER;
-                           RESULT      : out STD_LOGIC_VECTOR(3 downto 0);
-                           GOOD        : out BOOLEAN;
-                           ISSUE_ERROR : in  BOOLEAN) is
+    RESULT      : out STD_LOGIC_VECTOR(3 downto 0);
+    GOOD        : out BOOLEAN;
+    ISSUE_ERROR : in  BOOLEAN) is
   begin
     case C is
       when '0'       => RESULT := x"0"; GOOD := true;
@@ -82,9 +83,9 @@ package body LWC_TB_compatibility_pkg is
         GOOD := false;
     end case;
   end procedure Char2QuadBits;
- 
+
   procedure LWC_HREAD (L    : inout LINE; VALUE : out STD_LOGIC_VECTOR;
-                   GOOD : out   BOOLEAN) is
+    GOOD : out   BOOLEAN) is
     variable ok  : BOOLEAN;
     variable c   : CHARACTER;
     constant ne  : INTEGER := (VALUE'length+3)/4;
@@ -99,7 +100,7 @@ package body LWC_TB_compatibility_pkg is
       read (L, c, ok);
       i := 0;
       while i < ne loop
- 
+
         if not ok then
           GOOD := false;
           return;
@@ -136,7 +137,7 @@ package body LWC_TB_compatibility_pkg is
       GOOD := true;                     -- Null input string, skips whitespace
     end if;
   end procedure LWC_HREAD;
- 
+
   function LWC_to_hstring (value : STD_LOGIC_VECTOR) return STRING is
     constant ne     : INTEGER := (value'length+3)/4;
     variable pad    : STD_LOGIC_VECTOR(0 to (ne*4 - value'length) - 1);
@@ -180,5 +181,51 @@ package body LWC_TB_compatibility_pkg is
     end if;
   end function LWC_to_hstring;
 
-end package body LWC_TB_compatibility_pkg;
- 
+
+  shared variable seed1 : positive;
+  shared variable seed2 : positive;
+  
+  procedure seed(s : in positive) is
+  begin
+    seed1 := s;
+    if s > 1 then
+      seed2 := s - 1;
+    else
+      seed2 := s + 42;
+    end if;
+  end procedure;
+
+  procedure seed(s1, s2 : in positive) is
+  begin
+    seed1 := s1;
+    seed2 := s2;
+  end procedure;
+
+  impure function random return real is
+    variable result : real;
+  begin
+    uniform(seed1, seed2, result);
+    return result;
+  end function;
+
+  impure function randint(min, max : integer) return integer is
+  begin
+    return integer(trunc(real(max - min + 1) * random)) + min;
+  end function;
+
+  FUNCTION log2_ceil (N : NATURAL) RETURN NATURAL IS
+  BEGIN
+      IF (N = 0) THEN
+          RETURN 0;
+      ELSIF N <= 2 THEN
+          RETURN 1;
+      ELSE
+          IF (N MOD 2 = 0) THEN
+              RETURN 1 + log2_ceil(N/2);
+          ELSE
+              RETURN 1 + log2_ceil((N + 1)/2);
+          END IF;
+      END IF;
+  END FUNCTION log2_ceil;
+
+end package body LWC_TB_pkg;

--- a/hardware/LWC_tb/LWC_TB_pkg.vhd
+++ b/hardware/LWC_tb/LWC_TB_pkg.vhd
@@ -29,6 +29,7 @@ package LWC_TB_pkg is
     type LinkedList is protected
         procedure push(constant d   : in NATURAL);
         impure function pop return NATURAL;
+        impure function last return NATURAL;
         impure function isEmpty return BOOLEAN;
     end protected;
 
@@ -278,11 +279,18 @@ package body LWC_TB_pkg is
             deallocate(node);
             return ret;
         end;
+
+
+        impure function last return NATURAL is
+        begin
+            return root.d;
+        end;
  
         impure function isEmpty return BOOLEAN is
         begin
             return root = null;
         end;
+
  
     end protected body;
 

--- a/hardware/LWC_tb/LWC_TB_pkg.vhd
+++ b/hardware/LWC_tb/LWC_TB_pkg.vhd
@@ -182,30 +182,31 @@ package body LWC_TB_pkg is
   end function LWC_to_hstring;
 
 
-  shared variable seed1 : positive;
-  shared variable seed2 : positive;
+  -- shared variable seed1 : positive;
+  -- shared variable seed2 : positive;
   
   procedure seed(s : in positive) is
   begin
-    seed1 := s;
-    if s > 1 then
-      seed2 := s - 1;
-    else
-      seed2 := s + 42;
-    end if;
+  --   seed1 := s;
+  --   if s > 1 then
+  --     seed2 := s - 1;
+  --   else
+  --     seed2 := s + 42;
+    -- end if;
   end procedure;
 
   procedure seed(s1, s2 : in positive) is
   begin
-    seed1 := s1;
-    seed2 := s2;
+  --   seed1 := s1;
+  --   seed2 := s2;
   end procedure;
 
   impure function random return real is
-    variable result : real;
+    -- variable result : real;
   begin
-    uniform(seed1, seed2, result);
-    return result;
+    -- uniform(seed1, seed2, result);
+    -- return result;
+    return 0.0;
   end function;
 
   impure function randint(min, max : integer) return integer is

--- a/hardware/LWC_tb/LWC_TB_wrapper_conf.vhd
+++ b/hardware/LWC_tb/LWC_TB_wrapper_conf.vhd
@@ -1,0 +1,7 @@
+configuration LWC_TB_wrapper_conf of LWC_TB is
+    for TB
+        for all : LWC
+            use entity work.LWC_wrapper; -- either RTL or Verilog netlist
+        end for;
+    end for;
+end configuration;

--- a/hardware/LWC_tb/fwft_fifo_tb.vhd
+++ b/hardware/LWC_tb/fwft_fifo_tb.vhd
@@ -1,4 +1,11 @@
 --------------------------------------------------------------------------------
+--! @file       fwft_fifo_tb.vhd
+--! @brief      Simple First-In-First_Out
+--!
+--! @author     Patrick Karl <patrick.karl@tum.de>
+--! @copyright  Copyright (c) 2019 Chair of Security in Information Technology
+--!             ECE Department, Technical University of Munich, GERMANY
+--!--------------------------------------------------------------------------------
 --! @file       fwft_fifo.vhd
 --! @brief      Simple First-In-First_Out
 --!
@@ -18,7 +25,7 @@ use ieee.numeric_std.all;
 
 use work.NIST_LWAPI_pkg.all;
 
-entity fwft_fifo is
+entity fwft_fifo_tb is
 	generic(
         G_W         : integer; --! Width of I/O (bits)
         G_LOG2DEPTH : integer  --! LOG(2) of depth
@@ -36,15 +43,11 @@ entity fwft_fifo is
         dout        : out   std_logic_vector(G_W - 1 downto 0);
         dout_valid  : out   std_logic;
         dout_ready  : in    std_logic
-
-        --prog_full_th    : in    std_logic_vector(G_LOG2DEPTH - 1 downto 0);
-        --prog_full       : out   std_logic
     );
-end entity fwft_fifo;
+end entity fwft_fifo_tb;
 
-architecture structure of fwft_fifo is
-
-    -- FIFO depth in words
+architecture tb_use_only of fwft_fifo_tb is
+ -- FIFO depth in words
     constant DEPTH_C : integer := 2 ** G_LOG2DEPTH;
 
     -- Memory type and signal definition
@@ -165,4 +168,4 @@ begin
         end if;
     end process p_ptr_comb;
 
-end architecture structure;
+end architecture tb_use_only;

--- a/hardware/dummy_lwc/config.ini
+++ b/hardware/dummy_lwc/config.ini
@@ -5,7 +5,6 @@ G_TEST_MODE      = 4
 G_TEST_IPSTALL   = 10
 G_TEST_ISSTALL   = 100
 G_TEST_OSTALL    = 40
-G_LOG2_FIFODEPTH = 8
 G_FNAME_PDI      = "KAT/v1/pdi.txt"
 G_FNAME_SDI      = "KAT/v1/sdi.txt"
 G_FNAME_DO       = "KAT/v1/do.txt"

--- a/hardware/dummy_lwc/src_rtl/v1/LWC/LWC_wrapper.vhd
+++ b/hardware/dummy_lwc/src_rtl/v1/LWC/LWC_wrapper.vhd
@@ -1,0 +1,1 @@
+../../../../LWC_rtl/LWC_wrapper.vhd

--- a/hardware/dummy_lwc/src_rtl/v1/LWC/elastic_reg_fifo.vhd
+++ b/hardware/dummy_lwc/src_rtl/v1/LWC/elastic_reg_fifo.vhd
@@ -1,0 +1,1 @@
+../../../../LWC_rtl/elastic_reg_fifo.vhd

--- a/hardware/dummy_lwc/src_rtl/v1/LWC/fwft_fifo_tb.vhd
+++ b/hardware/dummy_lwc/src_rtl/v1/LWC/fwft_fifo_tb.vhd
@@ -1,1 +1,0 @@
-../../../../LWC_rtl/fwft_fifo_tb.vhd

--- a/hardware/dummy_lwc/src_rtl/v1/design_pkg.vhd
+++ b/hardware/dummy_lwc/src_rtl/v1/design_pkg.vhd
@@ -34,18 +34,19 @@ package design_pkg is
 ------------------------- DO NOT CHANGE ANYTHING BELOW -------------------------
 --------------------------------------------------------------------------------
     --! design parameters needed by the PreProcessor, PostProcessor, and LWC; assigned in the package body below!
-    constant TAG_SIZE        : integer; --! Tag size
-    constant HASH_VALUE_SIZE : integer; --! Hash value size
     
     constant CCSW            : integer; --! variant dependent design parameter!
     constant CCW             : integer; --! variant dependent design parameter!
-    constant CCWdiv8         : integer; --! derived from parameters above, assigned in body.
-
+    
     --! design parameters specific to the CryptoCore; assigned in the package body below!
     --! place declarations of your constants here
     constant NPUB_SIZE       : integer; --! Npub size
     constant DBLK_SIZE       : integer; --! Block size
-
+    constant TAG_SIZE        : integer; --! Tag size
+    constant HASH_VALUE_SIZE : integer; --! Hash value size
+    
+    constant CCWdiv8         : integer; --! derived from parameters above, assigned in body.
+    
     --! place declarations of your functions here
     --! Calculate the number of I/O words for a particular size
     function get_words(size: integer; iowidth:integer) return integer; 

--- a/hardware/dummy_lwc/src_tb/LWC_TB_compatibility_pkg.vhd
+++ b/hardware/dummy_lwc/src_tb/LWC_TB_compatibility_pkg.vhd
@@ -1,1 +1,0 @@
-../../LWC_tb/LWC_TB_compatibility_pkg.vhd

--- a/hardware/dummy_lwc/src_tb/LWC_TB_pkg.vhd
+++ b/hardware/dummy_lwc/src_tb/LWC_TB_pkg.vhd
@@ -1,0 +1,1 @@
+../../LWC_tb/LWC_TB_pkg.vhd

--- a/hardware/dummy_lwc/src_tb/fwft_fifo_tb.vhd
+++ b/hardware/dummy_lwc/src_tb/fwft_fifo_tb.vhd
@@ -1,0 +1,1 @@
+../../LWC_tb/fwft_fifo_tb.vhd

--- a/hardware/dummy_lwc/test_all.py
+++ b/hardware/dummy_lwc/test_all.py
@@ -150,7 +150,7 @@ def test_all():
     generated_sources = (core_src_path / 'generated_srcs')
     generated_sources.mkdir(exist_ok=True)
 
-    tb_files = [ str((core_src_path / 'src_tb' / s).resolve()) for s in ['LWC_TB_compatibility_pkg.vhd', 'LWC_TB.vhd'] ]
+    tb_files = [ str((core_src_path.parent / 'LWC_tb' / s).resolve()) for s in ['LWC_TB_pkg.vhd', 'LWC_TB.vhd'] ]
 
 
     for vhdl_std in ['93', '08']:

--- a/hardware/dummy_lwc/xedaproject.toml
+++ b/hardware/dummy_lwc/xedaproject.toml
@@ -1,0 +1,47 @@
+[project]
+description = "Implementation of the dummy_lwc cipher and hash"
+author = "[Patrick Karl](patrick.karl@tum.de)"
+url = "https://github.com/GMUCERG/LWC"
+
+[[design]]
+name = "dummy_lwc_v1"
+rtl.sources = [
+    "src_rtl/v1/design_pkg.vhd",
+    "src_rtl/v1/LWC/NIST_LWAPI_pkg.vhd",
+    "src_rtl/v1/SPDRam.vhd",
+    "src_rtl/v1/CryptoCore.vhd",
+    "src_rtl/v1/LWC/StepDownCountLd.vhd",
+    "src_rtl/v1/LWC/data_sipo.vhd",
+    "src_rtl/v1/LWC/key_piso.vhd",
+    "src_rtl/v1/LWC/data_piso.vhd",
+    "src_rtl/v1/LWC/fwft_fifo.vhd",
+    "src_rtl/v1/LWC/PreProcessor.vhd",
+    "src_rtl/v1/LWC/PostProcessor.vhd",
+    "src_rtl/v1/LWC/LWC.vhd",
+    "src_rtl/v1/LWC/elastic_reg_fifo.vhd",
+    "src_rtl/v1/LWC/LWC_wrapper.vhd",
+]
+rtl.top = 'LWC'
+rtl.clock_port = "clk"
+
+tb.top = 'LWC_TB'
+tb.sources = [
+    "src_rtl/v1/LWC/NIST_LWAPI_pkg.vhd",
+    "src_tb/LWC_TB_pkg.vhd",
+    "src_tb/LWC_TB.vhd",
+]
+
+language.vhdl.standard = "08"
+language.vhdl.synopsys = false
+
+[design.tb.generics]
+G_FNAME_PDI.file = "KAT/v1/pdi.txt"
+G_FNAME_SDI.file = "KAT/v1/sdi.txt"
+G_FNAME_DO.file  = "KAT/v1/do.txt"
+G_TEST_MODE = 0
+G_MAX_FAILURES = 0
+
+[flows.ghdl_sim]
+# ghw = 'dump_ghdl.ghw'
+vcd = 'dump_ghdl.vcd'
+# stop_time = '5us'

--- a/hardware/dummy_lwc/xedaproject.toml
+++ b/hardware/dummy_lwc/xedaproject.toml
@@ -27,8 +27,8 @@ rtl.clock_port = "clk"
 tb.top = 'LWC_TB'
 tb.sources = [
     "src_rtl/v1/LWC/NIST_LWAPI_pkg.vhd",
-    "src_tb/LWC_TB_pkg.vhd",
-    "src_tb/LWC_TB.vhd",
+    "../LWC_tb/LWC_TB_pkg.vhd",
+    "../LWC_tb/LWC_TB.vhd",
 ]
 
 language.vhdl.standard = "08"

--- a/software/cryptotvgen/cryptotvgen/cli.py
+++ b/software/cryptotvgen/cryptotvgen/cli.py
@@ -2,15 +2,14 @@
 # -*- coding: utf-8 -*-
 
 from .generator import gen_dataset, gen_hash, gen_random, gen_single, gen_test_combined, \
-         gen_test_routine, print_header, gen_benckmark_routine, gen_tv_and_write_files
+         gen_test_routine, print_header, gen_benchmark_routine, gen_tv_and_write_files, determine_params
 from .options import get_parser
-from .prepare_libs import prepare_libs
+from .prepare_libs import prepare_libs, ctgen_get_supercop_dir
 import textwrap
 import os
 import sys
 import errno
 import pathlib
-
 
 
 ## validation can only be safely done when all args are parsed and stored!
@@ -34,6 +33,12 @@ def run_cryptotvgen(args=sys.argv[1:]):
 
                     ''')
         sys.exit(error_txt)
+
+    if not opts.candidates_dir:
+        opts.candidates_dir = ctgen_get_supercop_dir()
+
+    # Update parameters based on api.h
+    determine_params(opts, opts.candidates_dir)
         
     # Additional error checking
     opts.msg_format = list(opts.msg_format)
@@ -57,9 +62,9 @@ def run_cryptotvgen(args=sys.argv[1:]):
     key_no = 1
     gen_single_index = 0
     
-    if opts.candidates_dir:
-        if not opts.lib_path:
-            opts.lib_path = pathlib.Path(opts.candidates_dir) / 'lib'
+    if opts.candidates_dir and not opts.lib_path:
+        opts.lib_path = pathlib.Path(opts.candidates_dir) / 'lib'
+
     for routine in opts.routines:
         if routine == 0:
             data = gen_random(opts, msg_no, key_no)
@@ -75,7 +80,7 @@ def run_cryptotvgen(args=sys.argv[1:]):
         elif routine == 5:   # Combined AEAD and Hash
             data = gen_test_combined(opts, msg_no, key_no)
         elif routine == 6:
-            gen_benckmark_routine(opts)
+            gen_benchmark_routine(opts)
             return 0
 
         dataset += data[0]

--- a/software/cryptotvgen/cryptotvgen/generator.py
+++ b/software/cryptotvgen/cryptotvgen/generator.py
@@ -190,8 +190,9 @@ def get_len(format, ad_len, pt_len):
     hex = '{:0{s}X}'.format(int(bin, 2), s=int(size*2))
     return hex
 
-def get_msg_format(format, ofile, decrypt, hashop):
+def get_msg_format(args, ofile, decrypt, hashop):
     ''' Create a msg format for pdi/sdi file '''
+    format = args.msg_dec_format if (decrypt and args.msg_dec_format) else args.msg_format
 
     msg_format = []
     tag = []
@@ -625,8 +626,7 @@ class TestVector(object):
             f.write('{}'.format(txt))
 
             # Write Segment
-            msg_format = get_msg_format(self.opts.msg_format,
-                                        ofile, self.decrypt, self.hashop)
+            msg_format = get_msg_format(self.opts, ofile, self.decrypt, self.hashop)
             for i, sgt in enumerate(msg_format):
 
                 if self.hashop:
@@ -851,7 +851,7 @@ class TestVector(object):
         f.write('#KEY\n{}\n{}\n'.format(new_key, self.key))
 
         # Write Segments
-        msg_format = get_msg_format(self.opts.msg_format,0,self.decrypt, self.hashop)
+        msg_format = get_msg_format(self.opts,0,self.decrypt, self.hashop)
         for i, sgt in enumerate(msg_format):
             # Data getter
             data = self.get_data(sgt)
@@ -867,9 +867,10 @@ class TestVector(object):
         file_path = os.path.join(self.opts.dest, HLS_CC_DO_FILE)
         f = open(file_path, 'a', newline='')
         f.write('#NEW\n\tMessage Number #{}\n'.format(self.msg_id))
-        msg_format = get_msg_format(self.opts.msg_format,1,self.decrypt, self.hashop)
+        msg_format = get_msg_format(self.opts,1,self.decrypt, self.hashop)
         for i, sgt in enumerate(msg_format):
             data = self.get_data(sgt)
+            eoi  = int(self.is_last_vld_segment(sgt, msg_format))
             self.wr_cc_hls_segment(f, data, eoi, sgt, True)
         f.write("#END\n\n")
         f.close()

--- a/software/cryptotvgen/cryptotvgen/generator.py
+++ b/software/cryptotvgen/cryptotvgen/generator.py
@@ -1204,10 +1204,22 @@ def basic_hash_sizes(block_size_msg_digest):
     return routine
 
 def blanket_message_aead_test(opts):
+    ad_bs = opts.block_size_ad//8
+    xt_bs = opts.block_size//8
+    sizes = list(range(10)) + [15, 16, 17, 29, 61, 63, 64, 65, 67, 97, 127, 128, 129,
+        ad_bs // 2 - 1, ad_bs // 2,
+        ad_bs - 1, ad_bs, ad_bs + 1,
+        2*ad_bs - 1, 2*ad_bs, 2*ad_bs + 1,
+        xt_bs - 1, xt_bs, xt_bs + 1,
+        xt_bs // 2 - 1, xt_bs // 2,
+        2*xt_bs - 1, 2*xt_bs, 2*xt_bs + 1,
+    ]
+    sizes=list(set(sizes))
     routine = []
-    for ad_size in range(2*opts.block_size_ad//8):
-        for mess_size in range(2*opts.block_size//8):
-            routine.append([True, False, ad_size, mess_size,False])
+    for ad_size in sizes:
+        for mess_size in sizes:
+            routine.extend([True, dec, ad_size, mess_size,False] for dec in [False, True])
+    print(f"blanket_message_aead_test: generating testvectors with {len(routine)} messages")
     return routine
 
 def basic_aead_sizes(new_key, enc_dec, block_size_ad, block_size_message):
@@ -1240,101 +1252,35 @@ def gen_benchmark_routine(opts):
 
     orig_dest=opts.dest
     if opts.hash:
-        data = gen_dataset(opts, blanket_message_hash_test(opts.block_size_msg_digest), 1, 1)
         opts.dest = os.path.join(orig_dest, 'blanket_hash_test')
+        print(f'Generating {os.path.abspath(opts.dest)}')
+        data = gen_dataset(opts, blanket_message_hash_test(opts.block_size_msg_digest), 1, 1)
         gen_tv_and_write_files(opts, data[0])
-        print(f'Generated: {os.path.abspath(opts.dest)}')
 
-        data = gen_dataset(opts, basic_hash_sizes(opts.block_size_msg_digest), 1, 1)
         opts.dest = os.path.join(orig_dest, 'basic_hash_sizes')
+        print(f'Generating {os.path.abspath(opts.dest)}')
+        data = gen_dataset(opts, basic_hash_sizes(opts.block_size_msg_digest), 1, 1)
         gen_tv_and_write_files(opts, data[0])
-        print(f'Generated: {os.path.abspath(opts.dest)}')
 
-    # Power measure runs
-    data = gen_dataset(opts, [[True, False, 0, 16, False]], 1, 1)
-    opts.dest = os.path.join(orig_dest, 'pow_0_16')
-    gen_tv_and_write_files(opts, data[0])
-    print(f'Generated: {os.path.abspath(opts.dest)}')
-    data = gen_dataset(opts, [[True, False, 16, 0, False]], 1, 1)
-    opts.dest = os.path.join(orig_dest, 'pow_16_0')
-    gen_tv_and_write_files(opts, data[0])
-    print(f'Generated: {os.path.abspath(opts.dest)}')
-    data = gen_dataset(opts, [[True, False, 16, 16, False]], 1, 1)
-    opts.dest = os.path.join(orig_dest, 'pow_16_16')
-    gen_tv_and_write_files(opts, data[0])
-    print(f'Generated: {os.path.abspath(opts.dest)}')
-
-    data = gen_dataset(opts, [[True, False, 0, 64, False]], 1, 1)
-    opts.dest = os.path.join(orig_dest, 'pow_0_64')
-    gen_tv_and_write_files(opts, data[0])
-    print(f'Generated: {os.path.abspath(opts.dest)}')
-    data = gen_dataset(opts, [[True, False, 64, 0, False]], 1, 1)
-    opts.dest = os.path.join(orig_dest, 'pow_64_0')
-    gen_tv_and_write_files(opts, data[0])
-    print(f'Generated: {os.path.abspath(opts.dest)}')
-    data = gen_dataset(opts, [[True, False, 64, 64, False]], 1, 1)
-    opts.dest = os.path.join(orig_dest, 'pow_64_64')
-    gen_tv_and_write_files(opts, data[0])
-    print(f'Generated: {os.path.abspath(opts.dest)}')
-
-    data = gen_dataset(opts, [[True, False, 0, 1536, False]], 1, 1)
-    opts.dest = os.path.join(orig_dest, 'pow_0_1536')
-    gen_tv_and_write_files(opts, data[0])
-    print(f'Generated: {os.path.abspath(opts.dest)}')
-    data = gen_dataset(opts, [[True, False, 1536, 0, False]], 1, 1)
-    opts.dest = os.path.join(orig_dest, 'pow_1536_0')
-    gen_tv_and_write_files(opts, data[0])
-    print(f'Generated: {os.path.abspath(opts.dest)}')
-    data = gen_dataset(opts, [[True, False, 1536, 1536, False]], 1, 1)
-    opts.dest = os.path.join(orig_dest, 'pow_1536_1536')
-    gen_tv_and_write_files(opts, data[0])
-    print(f'Generated: {os.path.abspath(opts.dest)}')
-
-    data = gen_dataset(opts, [[True, False, 0, 4*opts.block_size//8, False]], 1, 1)
-    opts.dest = os.path.join(orig_dest, 'pow_0_4x')
-    gen_tv_and_write_files(opts, data[0])
-    print(f'Generated: {os.path.abspath(opts.dest)}')
-    data = gen_dataset(opts, [[True, False, 4*opts.block_size_ad//8, 0, False]], 1, 1)
-    opts.dest = os.path.join(orig_dest, 'pow_4x_0')
-    gen_tv_and_write_files(opts, data[0])
-    print(f'Generated: {os.path.abspath(opts.dest)}')
-    data = gen_dataset(opts, [[True, False, 4*opts.block_size_ad//8, 4*opts.block_size//8, False]], 1, 1)
-    opts.dest = os.path.join(orig_dest, 'pow_4x_4x')
-    gen_tv_and_write_files(opts, data[0])
-    print(f'Generated: {os.path.abspath(opts.dest)}')
-
-    data = gen_dataset(opts, [[True, False, 0, 5*opts.block_size//8, False]], 1, 1)
-    opts.dest = os.path.join(orig_dest, 'pow_0_5x')
-    gen_tv_and_write_files(opts, data[0])
-    print(f'Generated: {os.path.abspath(opts.dest)}')
-    data = gen_dataset(opts, [[True, False, 5*opts.block_size_ad//8, 0, False]], 1, 1)
-    opts.dest = os.path.join(orig_dest, 'pow_5x_0')
-    gen_tv_and_write_files(opts, data[0])
-    print(f'Generated: {os.path.abspath(opts.dest)}')
-    data = gen_dataset(opts, [[True, False, 5*opts.block_size_ad//8, 5*opts.block_size//8, False]], 1, 1)
-    opts.dest = os.path.join(orig_dest, 'pow_5x_5x')
-    gen_tv_and_write_files(opts, data[0])
-    print(f'Generated: {os.path.abspath(opts.dest)}')
-
-    data = gen_dataset(opts, blanket_message_aead_test(opts), 1, 1)
     opts.dest = os.path.join(orig_dest, 'kats_for_verification')
+    print(f'Generating {os.path.abspath(opts.dest)}')
+    data = gen_dataset(opts, blanket_message_aead_test(opts), 1, 1)
     gen_tv_and_write_files(opts, data[0])
-    print(f'Generated: {os.path.abspath(opts.dest)}')
 
     # Ensure new key
+    opts.dest = os.path.join(orig_dest, 'generic_aead_sizes_new_key')
+    print(f'Generating {os.path.abspath(opts.dest)}')
     routine_new_key = [[True, False, 0, 0, False]]
     routine_new_key += basic_aead_sizes(True, False, opts.block_size_ad, opts.block_size)
     routine_new_key += basic_aead_sizes(True, True, opts.block_size_ad, opts.block_size)
     data_enc = gen_dataset(opts, routine_new_key, 1, 1)
-    opts.dest = os.path.join(orig_dest, 'generic_aead_sizes_new_key')
     gen_tv_and_write_files(opts, data_enc[0])
-    print(f'Generated: {os.path.abspath(opts.dest)}')
 
     # Ensure at least one new key
+    opts.dest = os.path.join(orig_dest, 'generic_aead_sizes_reuse_key')
+    print(f'Generating {os.path.abspath(opts.dest)}')
     routine_reuse_key = [[True, False, 0,0, False]]
     routine_reuse_key += basic_aead_sizes(False, False, opts.block_size_ad, opts.block_size)
     routine_reuse_key += basic_aead_sizes(False, True, opts.block_size_ad, opts.block_size)
     data_enc = gen_dataset(opts, routine_reuse_key, 1, 1)
-    opts.dest = os.path.join(orig_dest, 'generic_aead_sizes_reuse_key')
     gen_tv_and_write_files(opts, data_enc[0])
-    print(f'Generated: {os.path.abspath(opts.dest)}')

--- a/software/cryptotvgen/cryptotvgen/generator.py
+++ b/software/cryptotvgen/cryptotvgen/generator.py
@@ -234,19 +234,21 @@ def get_msg_format(format, ofile, decrypt, hashop):
 
 def get_test_vector_info(msgid, keyid, ad_len, pt_len, ct_len, decrypt, hashop, hash_tag_size):
     ''' Get a string of test vector information '''
+    data = dict(MsgID=msgid, KeyID=keyid)
     if (hashop):
         optxt = txt_opcode[getattr(Opcode, 'hash')]
-        data = 'Pt Size = {: 4}'.format(pt_len)
-        data = 'Hash_Tag Size = {: 4}'.format(hash_tag_size) # change later
+        data['HM Size'] = pt_len
+        data['Digest Size'] = hash_tag_size
     elif (decrypt):
         optxt = txt_opcode[getattr(Opcode, 'decrypt')]
-        data = 'Ct Size = {: 4}'.format(ct_len)
+        data['AD Size'] = ad_len
+        data['CT Size'] = ct_len
     else:
         optxt = txt_opcode[getattr(Opcode, 'encrypt')]
-        data = 'Pt Size = {: 4}'.format(pt_len)
-    txt  = '#### {}\n'.format(optxt)
-    txt += '#### MsgID={: 3}, KeyID={: 3} '.format(msgid, keyid)
-    txt += 'Ad Size = {: 4}, {}\n'.format(ad_len, data)
+        data['AD Size'] = ad_len
+        data['PT Size'] = pt_len
+    txt  = f'#### {optxt}\n'
+    txt += '#### ' + ', '.join([f'{k}={v}' for k,v in data.items()]) + '\n'
     return txt
 
 def instr_info(f):

--- a/software/cryptotvgen/cryptotvgen/generator.py
+++ b/software/cryptotvgen/cryptotvgen/generator.py
@@ -389,8 +389,8 @@ class TestVector(object):
         self.decrypt = op
         # Input
         self.key     = key
-        self.npub    = npub[:int(2*self.opts.npub_size/8)]
-        self.nsec_pt = nsec_pt[:int(2*self.opts.nsec_size/8)]
+        self.npub    = npub[:2*self.opts.npub_size//8]
+        self.nsec_pt = nsec_pt[:2*self.opts.nsec_size//8]
         self.ad      = ad
         self.pt      = pt
         self.partial = 0
@@ -400,7 +400,7 @@ class TestVector(object):
         self.tag = ''
         self.hash = pt
         self.hash_tag = ''
-        self.hash_tag_size = self.opts.message_digest_size/8
+        self.hash_tag_size = self.opts.message_digest_size // 8 if self.opts.message_digest_size is not None else None
 
     def aead_encrypt(self):
         ''' Compute aead algorithm '''
@@ -599,7 +599,7 @@ class TestVector(object):
                                        lenbytes(self.ct),
                                        self.decrypt,
                                        self.hashop,
-                                       int(self.hash_tag_size))
+                                       self.hash_tag_size)
             f.write('{}'.format(txt))
 
             if (not ofile):
@@ -635,19 +635,19 @@ class TestVector(object):
                 data = self.get_data(sgt)
 
                 # Sub-segment
-                max_sgmt = (self.opts.block_size/8)*self.opts.max_block_per_sgmt
-                tot_sgmt = int(math.ceil(lenbytes(data)/max_sgmt))
-                if (sgt in ['tag', 'hash_tag']):    # No segment split for tag/hash_tag
-                    tot_sgmt = 1
-                tot_sgmt = 1 if tot_sgmt == 0 else tot_sgmt
+                tot_sgmt = 1
+                max_sgmt = 0
+                # No segment split for tag/hash_tag
+                if sgt not in ['tag', 'hash_tag'] and self.opts.max_block_per_sgmt and self.opts.block_size:
+                    max_sgmt = (self.opts.block_size//8) * self.opts.max_block_per_sgmt
+                    tot_sgmt = max(1, int(math.ceil(lenbytes(data)/max_sgmt)))
 
-                (is_eoi, is_eot, is_lst) = (0,0,0)
+                is_eoi, is_eot, is_lst = (0,0,0)
                 for j in range(tot_sgmt):
                     begin = int(j*max_sgmt*2)
                     end = begin + int(max_sgmt*2)
                     if j == tot_sgmt-1:
-                        is_eoi = \
-                            int(self.is_last_vld_segment(sgt, msg_format))
+                        is_eoi = int(self.is_last_vld_segment(sgt, msg_format))
                         if (self.hashop and ofile):
                             is_lst = 1 if i == len(msg_format)-2 else 0
                         else:
@@ -934,6 +934,7 @@ def gen_dataset(opts, routine, start_msg_no, start_key_no, mode=0):
         return "".join(a)
 
     # print(routine)
+    assert opts.key_size and opts.npub_size is not None and opts.nsec_size is not None, "key_size npub_size nsec_size should be set"
     for i, tv in enumerate(routine):
         hashop = tv[4]
 
@@ -945,23 +946,23 @@ def gen_dataset(opts, routine, start_msg_no, start_key_no, mode=0):
             decrypt = tv[1]
 
         if mode == 2:
-            key  = get_running_value(opts.key_size/8)
-            npub = get_running_value(opts.npub_size/8)
-            nsec = get_running_value(opts.nsec_size/8)
+            key  = get_running_value(opts.key_size//8)
+            npub = get_running_value(opts.npub_size//8)
+            nsec = get_running_value(opts.nsec_size//8)
             ad   = get_running_value(tv[2])
             data = get_running_value(tv[3])
 
         elif mode == 1:
-            key  = '55'*int(opts.key_size/8)
-            npub = 'B0'*int(opts.npub_size/8)
-            nsec = '66'*int(opts.nsec_size/8)
+            key  = '55' * (opts.key_size//8)
+            npub = 'B0' * (opts.npub_size//8)
+            nsec = '66' * (opts.nsec_size//8)
             ad   = 'A0'*tv[2]
             data = 'FF'*tv[3]
 
         else:
-            key  = gen_data(int(opts.key_size/8),   mode, '55')
-            npub = gen_data(int(opts.npub_size/8),  mode, 'B0')
-            nsec = gen_data(int(opts.nsec_size/8),  mode, '66')
+            key  = gen_data(opts.key_size // 8,   mode, '55')
+            npub = gen_data(opts.npub_size // 8,  mode, 'B0')
+            nsec = gen_data(opts.nsec_size // 8,  mode, '66')
             ad   = gen_data(tv[2],          mode, 'A0')
             data = gen_data(tv[3],          mode, 'FF')
 
@@ -1145,37 +1146,45 @@ def gen_tv_and_write_files(opts, dataset):
             f.write('###EOF\n')
 
 
-def determine_params(opts):
-    '''This untility function will read in the parameters of the reference
+def determine_params(opts, candidates_dir):
+    '''This utility function will read in the parameters of the reference
     implementation api.h file and update the opts dict
     '''
-    algo_api_h = ctgen_get_supercop_dir() / 'crypto_aead' / opts.aead / "ref/api.h"
-    if not os.path.exists(algo_api_h):
-        sys.exit(f"{algo_api_h} does not exist. Ensure --aead is correct")
-    with open(algo_api_h, 'r') as f:
-        api_h = f.read()
-    log.debug(api_h)
-    for line in api_h.splitlines():
-        if "KEYBYTES" in line:
-            opts.key_size = 8 * int(line.split()[-1])
-        elif "NPUBBYTES" in line:
-            opts.npub_size = 8 * int(line.split()[-1])
-        elif "NSECBYTES" in line:
-            opts.nsec_size = 8 * int(line.split()[-1])
-        elif "NSECBYTES" in line:
-            opts.nsec_size = 8 * int(line.split()[-1])
-        elif "CRYPTO_ABYTES" in line:
-            opts.tag_size = 8 * int(line.split()[-1])
-    if opts.hash:
-        algo_hash_api_h = ctgen_get_supercop_dir() / 'crypto_hash' / opts.hash / "ref/api.h"
-        if not os.path.exists(algo_hash_api_h):
-            sys.exit(f"{algo_hash_api_h} did not exists. Ensure --hash is correct")
-        with open(algo_hash_api_h, 'r') as f:
-            hash_api_h = f.read()
-        log.debug(hash_api_h)
-        for line in hash_api_h.splitlines():
-            if "CRYPTO_BYTES" in line:
-                opts.message_digest_size = 8 * int(line.split()[-1])
+    api_map = {"CRYPTO_KEYBYTES": 'key_size', "CRYPTO_NPUBBYTES": 'npub_size', "CRYPTO_NSECBYTES": 'nsec_size', "CRYPTO_NSECBYTES": 'nsec_size', 
+        "CRYPTO_ABYTES": 'tag_size', "CRYPTO_BYTES": 'message_digest_size'
+        }
+    log.warning('Determining parameters automatically from api.h header files')
+    opts = vars(opts)
+    for op in ['aead', 'hash']:
+        alg = opts.get(op)
+        if not alg:
+            continue
+        impl_path = candidates_dir / f'crypto_{op}' / alg
+        api_h_files = list(impl_path.glob('**/api.h'))
+        if not api_h_files or len(api_h_files) < 1:
+            log.warning(f"No api.h files found in {impl_path}. Make sure --aead and/or --candidates_dir/--libs_dir are correct.")
+            print(f"No api.h files found in {impl_path}. Make sure --aead and/or --candidates_dir/--libs_dir are correct.")
+            return
+        if len(api_h_files) > 1:
+            log.warning("multiple api.h files found in the implementation folder.")
+        api_h = api_h_files[0]
+        if not os.path.exists(api_h):
+            log.warning(f"{api_h} does not exist. Ensure --aead and/or --candidates_dir/--libs_dir are correct.")
+            return
+
+        with open(api_h, 'r') as f:
+            api_h_content = f.read()
+
+        for line in api_h_content.splitlines():
+            splitted_line = line.split()
+            if len(splitted_line) >= 3 and splitted_line[0] == '#define':
+                k,v = splitted_line[1:3]
+                opt_attr = api_map.get(k)
+                if opt_attr:
+                    if opts[opt_attr] is None:
+                        v = int(v)*8
+                        log.info(f'From {api_h}: determined {opt_attr} to be {v} bits')
+                        opts[opt_attr] = v
 
 def blanket_message_hash_test(block_size_msg_digest):
     routine = []
@@ -1218,7 +1227,7 @@ def basic_aead_sizes(new_key, enc_dec, block_size_ad, block_size_message):
     return routine
 
 
-def gen_benckmark_routine(opts):
+def gen_benchmark_routine(opts):
     if (opts.verbose):
         print("gen_benckmark_routine")
     if not opts.aead or not opts.block_size or not opts.block_size_ad:
@@ -1227,8 +1236,6 @@ def gen_benckmark_routine(opts):
         sys.exit("If --hash algorithm is desired --block_size_msg_digest is required")
     log.debug(f"original options \n{opts}\n")
 
-    # Update parameters based on api.h
-    determine_params(opts)
     orig_dest=opts.dest
     if opts.hash:
         data = gen_dataset(opts, blanket_message_hash_test(opts.block_size_msg_digest), 1, 1)
@@ -1313,7 +1320,7 @@ def gen_benckmark_routine(opts):
     print(f'Generated: {os.path.abspath(opts.dest)}')
 
     # Ensure new key
-    routine_new_key = [[True, False, 0,0, False]]
+    routine_new_key = [[True, False, 0, 0, False]]
     routine_new_key += basic_aead_sizes(True, False, opts.block_size_ad, opts.block_size)
     routine_new_key += basic_aead_sizes(True, True, opts.block_size_ad, opts.block_size)
     data_enc = gen_dataset(opts, routine_new_key, 1, 1)

--- a/software/cryptotvgen/cryptotvgen/generator.py
+++ b/software/cryptotvgen/cryptotvgen/generator.py
@@ -192,7 +192,8 @@ def get_len(format, ad_len, pt_len):
 
 def get_msg_format(args, ofile, decrypt, hashop):
     ''' Create a msg format for pdi/sdi file '''
-    format = args.msg_dec_format if (decrypt and args.msg_dec_format) else args.msg_format
+    dec_fmt = args.dec_msg_format
+    format = dec_fmt if decrypt and dec_fmt else args.msg_format
 
     msg_format = []
     tag = []

--- a/software/cryptotvgen/cryptotvgen/options.py
+++ b/software/cryptotvgen/cryptotvgen/options.py
@@ -87,7 +87,7 @@ class ValidateCandidatesDir(argparse.Action):
         super(ValidateCandidatesDir, self).__init__(option_strings, dest, nargs, **kwargs)
 
     def __call__(self, parser, namespace, value, option_string=None):
-        value = pathlib.Path(value).resolve()
+        value = pathlib.Path(value)
         if not (value.exists() and value.is_dir()):
             sys.exit(f"candidate_dir {value} does not exist or is not a directory!")
         setattr(namespace, self.dest, value)
@@ -441,12 +441,11 @@ def get_parser():
             '''))
 
     test.add_argument(
-        '--gen_custom', type=str,
-        metavar=('Array'), action=ValidateGenCustom,
+        '--gen_custom', type=str, metavar=('<parameters[:parameters]*>'), action=ValidateGenCustom,
         help=textwrap.dedent('''\
             Randomly generate multiple test vectors, with each test vector
             specified using the following fields:
-               NEW_KEY (Boolean), DECRYPT (Boolean), AD_LEN, PT_LEN or
+               NEW_KEY (Boolean), DECRYPT (Boolean), AD_LEN, PT_LEN or CT_LEN or
                HASH_LEN, HASH (Boolean)
                ":" is used as a separator between two consecutive test
                vectors.
@@ -707,22 +706,22 @@ def get_parser():
         metavar=('PUBLIC_PORTS_WIDTH', 'SECRET_PORT_WIDTH'),
         help='Size of PDI/DO and SDI port in bits.')
     impops.add_argument(
-        '--key_size', type=int, default=128, metavar='BITS',
+        '--key_size', type=int, default=None, metavar='BITS',
         help='Size of key in bits')
     impops.add_argument(
-        '--npub_size', type=int, default=128, metavar='BITS',
+        '--npub_size', type=int, default=None, metavar='BITS',
         help='Size of public message number in bits')
     impops.add_argument(
-        '--nsec_size', type=int, default=0, metavar='BITS',
+        '--nsec_size', type=int, default=None, metavar='BITS',
         help='Size of secret message number in bits')
     impops.add_argument(
-        '--tag_size', type=int, default=128, metavar='BITS',
+        '--tag_size', type=int, default=None, metavar='BITS',
         help='Size of authentication tag in bits')
     impops.add_argument(
-        '--message_digest_size', type=int, default=64, metavar='BITS',
+        '--message_digest_size', type=int, default=None, metavar='BITS',
         help='Size of message digest (hash_tag) in bits')
     impops.add_argument(
-        '--block_size', type=int, default=128, metavar='BITS',
+        '--block_size', type=int, default=None, metavar='BITS',
         help='''Algorithm's data block size''')
     impops.add_argument(
         '--block_size_ad', type=int, metavar='BITS',
@@ -853,7 +852,7 @@ def get_parser():
         '--max_d', type=int, default=1000, metavar='BYTES',
         help='Maximum randomly generated data length')
     tvops.add_argument(
-        '--max_block_per_sgmt', type=int, default=9999, metavar='COUNT',
+        '--max_block_per_sgmt', type=int, default=None, metavar='COUNT',
         help='Maximum data block per segment (based on --block_size) parameter')
     tvops.add_argument(
         '--max_io_per_line', type=int, default=9999, metavar='COUNT',

--- a/software/cryptotvgen/cryptotvgen/options.py
+++ b/software/cryptotvgen/cryptotvgen/options.py
@@ -785,18 +785,21 @@ def get_parser():
         '--msg_format', nargs='+', action=ValidateMsgFormat,
         default=('npub', 'ad', 'data', 'tag'), metavar='SEGMENT_TYPE',
         help=textwrap.dedent('''\
-            Specify the order of segment types in the input to encryption and
-            decryption. Tag is always omitted in the input to encryption, and
+            Specify the order of segment types in the input to encryption.
+            If --msg_dec_format is not specified, the specified order is used 
+            for decryption as well.
+            Tag is always omitted in the input to encryption, and
             included in the input to decryption. In the expected output from
             encryption tag is always added last. In the expected output from
             decryption only nsec and data are used (if specified).
+            
             Len is always automatically added as a first segment in the
             input for encryption and decryption for the offline algorithms.
             Len is not allowed as an input to encryption or decryption for
             the online algorithms.
 
             Example 1:
-            --msg_format npub tag data ad
+                --msg_format npub tag data ad
 
             The above example generates
             for an input to encryption: npub, data (plaintext), ad
@@ -805,7 +808,7 @@ def get_parser():
             for an expected output from decryption: data (plaintext)
 
             Example 2:
-            --msg_format npub_ad data_tag
+                --msg_format npub_ad data_tag
 
             The above example generates
             for an input to encryption:  npub_ad, data (plaintext)
@@ -826,6 +829,34 @@ def get_parser():
             Note: no support for multiple segments of the same type,
             separated by segments of another type e.g., header and trailer,
             treated as two segments of the type AD, separated by the message segments
+
+            '''))
+    tvops.add_argument(
+        '--msg_dec_format', nargs='+', action=ValidateMsgFormat,
+        default=None, metavar='SEGMENT_TYPE',
+        help=textwrap.dedent('''\
+            Specify the order of segment types in the input to decryption.
+            If not specified, the order specifed in `--msg_format` (or its default value) is used.
+
+            Valid Segment types (case-insensitive):
+                npub    -> public message number
+                nsec    -> secret message number
+                ad      -> associated data
+                ad_npub -> associated data || npub
+                npub_ad -> npub || associated data
+                data    -> data (pt/ct)
+                data_tag -> data (pt/ct) || tag
+                tag     -> authentication tag
+
+            'tag' is always omitted in the input to encryption, and
+            included in the input to decryption.
+            In the expected output from
+            decryption only 'nsec' and 'data' are used (if specified).
+
+            Please see the help on `--msg_format` for further details.
+
+            Example:
+                --msg_dec_format npub tag data ad
 
             '''))
     tvops.add_argument(

--- a/software/cryptotvgen/cryptotvgen/options.py
+++ b/software/cryptotvgen/cryptotvgen/options.py
@@ -782,7 +782,7 @@ def get_parser():
     tvops = parser.add_argument_group(
         '', 'Formatting options::')
     tvops.add_argument(
-        '--msg_format', nargs='+', action=ValidateMsgFormat,
+        '--msg_format', '--enc_msg_format', nargs='+', action=ValidateMsgFormat,
         default=('npub', 'ad', 'data', 'tag'), metavar='SEGMENT_TYPE',
         help=textwrap.dedent('''\
             Specify the order of segment types in the input to encryption.
@@ -832,7 +832,7 @@ def get_parser():
 
             '''))
     tvops.add_argument(
-        '--msg_dec_format', nargs='+', action=ValidateMsgFormat,
+        '--dec_msg_format', nargs='+', action=ValidateMsgFormat,
         default=None, metavar='SEGMENT_TYPE',
         help=textwrap.dedent('''\
             Specify the order of segment types in the input to decryption.

--- a/software/cryptotvgen/cryptotvgen/prepare_libs.py
+++ b/software/cryptotvgen/cryptotvgen/prepare_libs.py
@@ -146,7 +146,7 @@ def prepare_libs(sc_version, libs, candidates_dir, lib_path):
         incl_candidates = set()
         extract_list = []
 
-        crypto_dir_regexps = {crypto_type:[re.compile(f'supercop-{sc_version}/crypto_{crypto_type}/([^/]+)/{d}/') for d in impl_src_dirs]
+        crypto_dir_regexps = {crypto_type:[re.compile(f'supercop-{sc_version}/crypto_{crypto_type}/([^/]+)/.*/')]
                               for crypto_type in lwc_candidates.keys()}
 
         # TODO make this more efficient, though unlikely to be a performance bottleneck
@@ -179,7 +179,7 @@ def prepare_libs(sc_version, libs, candidates_dir, lib_path):
         if os.path.exists(candidates_dir):
             shutil.rmtree(candidates_dir)
         shutil.copytree(str(pathlib.Path(tmp_dir) / f'supercop-{sc_version}'),
-                        str(candidates_dir))
+                        str(candidates_dir), symlinks=True)
         shutil.rmtree(tmp_dir)
         print('moved sources to cryptotvgen data dir')
     else:

--- a/software/cryptotvgen/setup.py
+++ b/software/cryptotvgen/setup.py
@@ -17,7 +17,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='1.1.0',
+    version='1.1.1',
 
     description='Cryptographic Hardware Test Vectors Generator',
     long_description='Cryptographic Hardware Test Vectors Generator for SuperCop software library.',


### PR DESCRIPTION
- Restructure and many fixes for LWC_TB
  - Fixed post-synth/post-PnR timings simulation
  - Support for two-pass implementations (LWC_2pass)
  - Rewrite of timing measurement mode
  - Simplify and cleanup: shrink LWC_TB from ~1000 lines to ~500 lines
  - Support for wrapped LWC to break combination I/O paths
- Rename: LWC_TB_compatibility_pkg -> LWC_TB_pkg
- cyptotvgen: Fix prepare_lib on custom candidates_dir
- cyptotvgen: Fix parameter extraction from api.h
- cyptotvgen: support for different encryption and decryption message format (order)
- cyptotvgen: support for newer versions of SUPERCOP
+ other fixes